### PR TITLE
Update RFC0010-SSH-Remoting-Cmdlets.md

### DIFF
--- a/1-Draft/RFC0010-SSH-Remoting-Cmdlets.md
+++ b/1-Draft/RFC0010-SSH-Remoting-Cmdlets.md
@@ -2,7 +2,7 @@
 RFC: 0010
 Author: Paul Higinbotham
 Status: Draft
-Version 0.1
+Version: 0.1
 Area: Remoting
 ---
 


### PR DESCRIPTION
I noticed that the document header wasn't displaying correctly so added missing colon character.
