### PR TITLE
New RFC - Dot referencing with decimal integer literals

### DIFF
--- a/1-Draft/RFC0011-Dot-Referencing-With-Static-Integers.md
+++ b/1-Draft/RFC0011-Dot-Referencing-With-Static-Integers.md
@@ -1,5 +1,5 @@
 ---
-RFC: XXXX
+RFC: 0011
 Author: Kirk Munro
 Status: Draft
 SupercededBy: N/A

--- a/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
+++ b/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
@@ -219,9 +219,47 @@ Cons:
  + Risks breaking much more code.
  + Adds syntax complexity that shouldn't be necessary.
 
- ## Additional Details
+### Provide a way to define units for numeric values
 
- As a learning exercise, I decided to figure out how to fix this in the
- PowerShell Core project over the weekend. If you'd like to try the fix out,
- or if you would like to see the changes required for this fix, visit
- https://github.com/KirkMunro/PowerShell/commit/842575e49b8b5f5336881bdc219dceae9d90fbee
+This isn't really an alternative, because the proposed changes are required for
+proper method invocation on a static integer value -- it's more of an extension
+of the idea. It may be interesting to specifically allow the definition of
+units that would be automatically supported on static numeric values that do
+not already have a unit added to them, where unit names (which are simply a
+series of characters such as KB, MB, days, years, weeks, etc) would be
+associated with a multiplier/converter script that would automatically resolve
+the numeric value with the unit in the appropriate type (based on the script).
+
+Pros:
+ + Eliminates the magic in KB, MB, GB, TB, and PB units and provides a unit
+ extension point in PowerShell.
+
+Cons:
+ + Since this is an extension of the main idea, it would probably be best to
+ consider it in a completely separate RFC.
+  
+## Additional Details
+
+If this RFC gets accepted, as an added benefit to the PowerShell language it
+would be possible to implement units on any numeric constant as a property of
+the appropriate numeric type. Since PowerShell v1, there has been support for
+units of KB, MB, GB, TB, and later PB was added as well. The way this support
+is implemented has always been parser magic, meaning that the parser has extra
+internal logic hardcoded to apply these units to static numeric values that it
+encounters. These are not the only units that are desirable in the PowerShell
+scripting language. This change would allow for ETS extensions to define units
+for numeric types that are then accessible as properties (invoked using a dot-
+reference operator). For example, time units to define time spans (seconds,
+minutes, hours, days, weeks, months, years). You can see these units defined in
+my TypePx module. The existing limitation of having to wrap integers in
+brackets hurts the end user experience when applying these units in a script.
+Fixing this inconsistency would allow for easier invocation of these units, and
+would encourage such units to be invoked as members (which you can do with KB,
+MB, GB, TB, and PB today -- e.g. 2.MB). This would be a better way to implement
+units in PowerShell, with less magic and more applied logic that can be used
+in a repeatable, consistent manner. 
+
+Also, as a learning exercise, I decided to figure out how to fix this in the
+PowerShell Core project over the weekend. If you'd like to try the fix out,
+or if you would like to see the changes required for this fix, visit
+https://github.com/KirkMunro/PowerShell/commit/842575e49b8b5f5336881bdc219dceae9d90fbee

--- a/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
+++ b/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
@@ -2,6 +2,7 @@
 RFC: XXXX
 Author: Kirk Munro
 Status: Draft
+SupercededBy: N/A
 Version: 0.1
 Area: Parsing Static Numbers
 Comments Due: November 4, 2016
@@ -129,12 +130,11 @@ This RFC is about correcting these inconsistencies.
 
 ## Motivation
 
-As a PowerShell user, I value consistency and discoverability very highly, as
-they allow me to apply knowledge I have learned about PowerShell throughout My
-work with the language and make intelligent decisions that are based on My
-knowledge of the language with a high level of confidence. I also value the
-simplicity and elegance that can be achieved with code that doesn't require a
-lot of unnecessary syntax in order to make it work properly.
+As a PowerShell user, I can invoke members on every static numeric value the
+same way, with simplicity and elegance and without having to consider the type
+of numeric value, so that my user experience remains consistent and reliable by
+making sure that members on static numeric values are easily discoverable and
+accessible.
 
 ## Specification
 
@@ -262,4 +262,4 @@ in a repeatable, consistent manner.
 Also, as a learning exercise, I decided to figure out how to fix this in the
 PowerShell Core project over the weekend. If you'd like to try the fix out,
 or if you would like to see the changes required for this fix, visit
-https://github.com/KirkMunro/PowerShell/commit/842575e49b8b5f5336881bdc219dceae9d90fbee
+https://github.com/PowerShell/PowerShell/compare/master...KirkMunro:parsing-static-integers

--- a/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
+++ b/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
@@ -1,5 +1,5 @@
 ---
-RFC: 0011
+RFC: XXXX
 Author: Kirk Munro
 Status: Draft
 Version: 0.1

--- a/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
+++ b/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
@@ -4,14 +4,14 @@ Author: Kirk Munro
 Status: Draft
 SupercededBy: N/A
 Version: 0.1
-Area: Parsing Static Numbers
+Area: Parsing Literal Numbers
 Comments Due: November 4, 2016
 ---
 
-# Parsing Static Numbers
+# Parsing literal Numbers
 
-PowerShell has multiple inconsistencies in the parser when parsing static
-numbers. Static numbers include any of the following:
+PowerShell has multiple inconsistencies in the parser when parsing literal
+numbers. Literal numbers include any of the following:
 
 ```PowerShell
 3
@@ -36,24 +36,24 @@ numbers. Static numbers include any of the following:
 0xabcdl
 ```
 
-In addition, any of these static numbers may be preceded by a sign (+/-), and
-any of these static numbers may have a byte-size unit (KB/MB/GB/TB/PB) appended
-to the end. With all supported pieces in place, you can end up with a static
-number that looks like one of these:
+In addition, any of these literal numbers may be preceded by a sign (+/-), and
+any of these literal numbers may have a byte-size unit (KB/MB/GB/TB/PB)
+appended to the end. With all supported pieces in place, you can end up with a
+literal number that looks like one of these:
 
 ```PowerShell
 -1e+10lmb # Equal to -10485760000000000
 0xabcdefgb # Equal to 12089661849600000
 ```
 
-Since static numbers (including their sign, type suffix, and byte-size unit)
+Since literal numbers (including their sign, type suffix, and byte-size unit)
 evaluate to objects like any other, be they int32, int64, decimal, or double,
 and since objects have property and method members, you can invoke a member by
-dot-referencing the member name immediately at the end of the static number,
-except for int32 or int64 static numbers that don't have a type suffix nor a
+dot-referencing the member name immediately at the end of the literal number,
+except for int32 or int64 literal numbers that don't have a type suffix nor a
 byte-size unit. That is to say, you can invoke members directly at the end of
-_most_ static number formats, but you can't invoke members directly at the end
-of int32 or int64 static numbers that don't have a suffix. These are parsed
+_most_ literal number formats, but you can't invoke members directly at the end
+of int32 or int64 literal numbers that don't have a suffix. These are parsed
 and evaluated just fine today:
 
 ```PowerShell
@@ -76,8 +76,8 @@ Update-TypeData -TypeName int -MemberName days -MemberType ScriptProperty `
 2.Equals(3)
 ```
 
-This demonstrates an inconsistency in how PowerShell handles static numbers.
-The workaround is to wrap the static numbers in brackets, in which case you
+This demonstrates an inconsistency in how PowerShell handles literal numbers.
+The workaround is to wrap the literal numbers in brackets, in which case you
 can invoke members just fine. For example this works:
 
 ```
@@ -85,25 +85,25 @@ can invoke members just fine. For example this works:
 ```
 
 That extra set of brackets shouldn't be necessary though, because it isn't
-necessary for all of the other static number formats. This is simply a design
+necessary for all of the other literal number formats. This is simply a design
 bug in the PowerShell parser. In vanilla PowerShell this isn't a huge issue,
 because int32 and int64 objects don't have many properties or methods on them
-that you would want to use with static values; however, since PowerShell has
+that you would want to use with literal values; however, since PowerShell has
 a rich extensibility model, there are many opportunities to add properties and
-methods to the extended type system that make great sense to use with static
+methods to the extended type system that make great sense to use with literal
 values, and it is with all of these that having to use round brackets gets in
 the way (example: ```Get-EventLog -LogName System -After 2.weeks.ago```).
 
-The inconsistency continues beyond simple invocation of members on static
+The inconsistency continues beyond simple invocation of members on literal
 numerics. When PowerShell parses a script, if it finds a token that it
 identifies as a number, whether that token is followed by a dot-reference of a
 member or not, then PowerShell will treat it as a number. This means that if
-you create a command whose name is recognized by the parser as a static numeric
-value or as a static numeric value followed by a dot-reference to a member, then
+you create a command whose name is recognized by the parser as a literal numeric
+value or as a literal numeric value followed by a dot-reference to a member, then
 you will not be able to invoke that command unless you use the call operator or
 the dot-source operator. The reason for this is that the parser checks for
-static numeric values before it checks for commands. This is the case for every
-format of static numeric values, except for integers that are not followed by a
+literal numeric values before it checks for commands. This is the case for every
+format of literal numeric values, except for integers that are not followed by a
 type suffix nor by a byte-size unit. This results in some unexpected behaviour
 due to the inconsistency.
 
@@ -117,37 +117,37 @@ function 1d.GetGroupMembers {...}
 ```
 
 Once these are created, you can invoke each of these functions normally except
-for the last one because the parser recognizes it as a static decimal value
+for the last one because the parser recognizes it as a literal decimal value
 followed by a member invocation. With strict mode turned off, this invocation
 would simply return nothing to the user. Regardless of where the command comes
 from (batch file, executable program, PowerShell function or alias), if the
-command is parsable as a static number or as a static number with a member
+command is parsable as a literal number or as a literal number with a member
 invocation, then invoking that command requires a call operator (unless the
-static number happens to be an integer -- then it works today due to the design
+literal number happens to be an integer -- then it works today due to the design
 issue mentioned earlier).
 
 This RFC is about correcting these inconsistencies.
 
 ## Motivation
 
-As a PowerShell user, I can invoke members on every static numeric value the
+As a PowerShell user, I can invoke members on every literal numeric value the
 same way, with simplicity and elegance and without having to consider the type
 of numeric value, so that my user experience remains consistent and reliable by
-making sure that members on static numeric values are easily discoverable and
+making sure that members on literal numeric values are easily discoverable and
 accessible.
 
 ## Specification
 
-The proposal is to fix the parser in PowerShell Core such that static integer
-values followed by a dot-reference of a member are properly recognized as just
-that, bringing the integer format in line with the rest of the numeric formats
-that are used in PowerShell. With the appropriate changes in place, users will
-be able to dot-reference any member after any static numeric value, Regardless
-of the format of that static numeric value.
+The proposal is to fix the parser in PowerShell Core such that decimal literal
+integer values followed by a dot-reference of a member are properly recognized
+as just that, bringing the integer format in line with the rest of the numeric
+formats that are used in PowerShell. With the appropriate changes in place,
+users will be able to dot-reference any member after any literal numeric value,
+regardless of the format of that literal numeric value.
 
 Examples:
 
-Invoking an ETS property on a static integer value:
+Invoking an ETS property on a decimal literal integer value:
 ```PowerShell
 PS C:\> Update-TypeData -TypeName int -MemberName weeks -MemberType ScriptProperty -Value {New
 -TimeSpan -Days ($this*7)} -Force
@@ -169,8 +169,8 @@ TotalMilliseconds : 1209600000
 PS C:\>
 ```
 
-Invoking a command with a name that parses as a static integer value that
-dot-references a member: 
+Invoking a command with a name that parses as a decimal literal integer value
+that dot-references a member: 
 ```PowerShell
 PS C:\> function 4.StartService {Start-Service wuauserv}
 PS C:\> 4.StartService # Nothing happens because it's not parsed as a command
@@ -178,22 +178,22 @@ PS C:\>
 ```
 
 Pros: 
- + Ensures consistency among static numeric value use regardless of the format,
+ + Ensures consistency among literal numeric value use regardless of the format,
  whether you're invoking members or commands that look like numeric values
  followed by member invocations.  
  + Prefers simplicity and elegance over unnecessary syntax complexity.
 
 Cons:
- + Would break commands whose name evaluates as a static integer value followed
- by a dot-reference of a member
+ + Would break commands whose name evaluates as a decimal literal integer value
+ followed by a dot-reference of a member
 
 ## Alternate Proposals and Considerations
 
 ### Warn on command invocations that cannot be invoked without call/dot-source
 
 As an addition to the proposal above, the parser could also identify commands
-that are hidden by static numeric values followed by a dot-reference of a
-member.
+that are hidden by literal numeric values followed by a dot-reference of a
+member and warn the user about the hidden commands.
 
 Pros:
  + Improves discoverability and makes it easier for users to invoke commands
@@ -209,7 +209,7 @@ Cons:
 ### Move the consistency needle the other way
 
 As an alternative of the proposal above, the consistency needle could be moved
-the other way, requiring all static numeric values to be wrapped in brackets in
+the other way, requiring all literal numeric values to be wrapped in brackets in
 order to dot-reference members on them.
 
 Pros:
@@ -222,13 +222,14 @@ Cons:
 ### Provide a way to define units for numeric values
 
 This isn't really an alternative, because the proposed changes are required for
-proper method invocation on a static integer value -- it's more of an extension
-of the idea. It may be interesting to specifically allow the definition of
-units that would be automatically supported on static numeric values that do
-not already have a unit added to them, where unit names (which are simply a
-series of characters such as KB, MB, days, years, weeks, etc) would be
-associated with a multiplier/converter script that would automatically resolve
-the numeric value with the unit in the appropriate type (based on the script).
+proper method invocation on a decimal literal integer value -- it's more of an
+extension of the idea. It may be interesting to specifically allow the
+definition of units that would be automatically supported on literal numeric
+values that do not already have a unit added to them, where unit names (which
+are simply a series of characters such as KB, MB, days, years, weeks, etc)
+would be associated with a multiplier/converter script that would automatically
+resolve the numeric value with the unit in the appropriate type (based on the
+script).
 
 Pros:
  + Eliminates the magic in KB, MB, GB, TB, and PB units and provides a unit
@@ -245,13 +246,13 @@ would be possible to implement units on any numeric constant as a property of
 the appropriate numeric type. Since PowerShell v1, there has been support for
 units of KB, MB, GB, TB, and later PB was added as well. The way this support
 is implemented has always been parser magic, meaning that the parser has extra
-internal logic hardcoded to apply these units to static numeric values that it
+internal logic hardcoded to apply these units to literal numeric values that it
 encounters. These are not the only units that are desirable in the PowerShell
 scripting language. This change would allow for ETS extensions to define units
 for numeric types that are then accessible as properties (invoked using a dot-
 reference operator). For example, time units to define time spans (seconds,
 minutes, hours, days, weeks, months, years). You can see these units defined in
-my TypePx module. The existing limitation of having to wrap integers in
+the TypePx module. The existing limitation of having to wrap integers in
 brackets hurts the end user experience when applying these units in a script.
 Fixing this inconsistency would allow for easier invocation of these units, and
 would encourage such units to be invoked as members (which you can do with KB,
@@ -262,4 +263,4 @@ in a repeatable, consistent manner.
 Also, as a learning exercise, I decided to figure out how to fix this in the
 PowerShell Core project over the weekend. If you'd like to try the fix out,
 or if you would like to see the changes required for this fix, visit
-https://github.com/PowerShell/PowerShell/compare/master...KirkMunro:parsing-static-integers
+https://github.com/PowerShell/PowerShell/compare/master...KirkMunro:parsing-literal-integers

--- a/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
+++ b/1-Draft/RFCXXXX-Dot-Referencing-With-Static-Integers.md
@@ -263,4 +263,4 @@ in a repeatable, consistent manner.
 Also, as a learning exercise, I decided to figure out how to fix this in the
 PowerShell Core project over the weekend. If you'd like to try the fix out,
 or if you would like to see the changes required for this fix, visit
-https://github.com/PowerShell/PowerShell/compare/master...KirkMunro:parsing-literal-integers
+https://github.com/PowerShell/PowerShell/compare/master...KirkMunro:parsing-static-integers


### PR DESCRIPTION
This RFC is to allow for member invocation on static integers without brackets.