### PR TITLE
Proposals for nested errors and stack trace printing.

### DIFF
--- a/1-Draft/RFCNNNN-Nested-Exceptions.md
+++ b/1-Draft/RFCNNNN-Nested-Exceptions.md
@@ -1,0 +1,94 @@
+---
+RFC: 
+Author: Sergey Babkin
+Status: Draft
+Area: Error handling
+Comments Due: 
+---
+
+# Nested Exceptions
+
+.NET provides for the concept of the nested exceptions, however using the nested
+errors in PowerShell is not easy: handling of the PowerShell Script Stack is 
+non-obvious, and the default error formatter doesn't print the nested errors
+thus requiring the manual support for them.
+
+This proposal describes how the nested exceptions can be implemented in
+PowerShell and supported transparently in the syntax of the language (finally and throw
+statements).
+
+## Motivation
+
+The nested errors are highly useful for two reasons:
+
+1. Nested error reporting as such, where the low-level inner error gets wrapped
+into the more high-level and user-friendly explanations, allowing to trace the
+whole sequence of dependencies that led to the error.
+
+2. Reporting of the errors from the try/finally blocks. If an exception gets
+thrown from the try block, and another one from the finally block, it's highly
+desirable to see both errors (currently the error in the finally block overwrites
+the error from the try block thus making it undiagnosable). The nested try/fianlly
+blocks may cause the longish error chains to be created.
+
+This proposal is based on my experience described in https://blogs.msdn.microsoft.com/sergey_babkins_blog/2016/12/30/reporting-the-nested-errors-in-powershell/ . This link describes an implementation with the scripting functions but the same
+can be implemented in a more convenient and transparent way in the language itself.
+
+## Specification
+
+The proposed changes to the language are:
+
+1. The "throw" statement with an array argument should create a nested exception.
+The direction of nesting can be chosen at will but the specific proposed direction is
+to make the first element of the array into the innermost exception, the last element
+into the outermost exception that gets re-thrown. If any of the exceptions in the array
+are nested themselves, they will become concatenated as a part of the resulting
+full list of exceptions.
+
+2. If a "finally" block was called due to an exception in the "try" block and
+an exception happens in this "finally" block, the result will be a nested exception,
+where the original exception from the "try" block will be the inner exception and the
+new one will be the outer exception.
+
+3. If a "catch" block throws an exception, it should probably also create a nested
+exception in the same way as the "finally" block. This would be a change of behavior
+for the programs that already re-throw an exception in some processed way, so possibly this
+behavior should be explicitly enabled by setting some special variable, such as
+$PSCatchNest = $true, or possibly by provising some parameter to "catch".
+
+The proposed implementation the nested error chains from an array is as follows:
+
+* The elements of the array may be of the types System.Management.Automation.ErrorRecord,
+Exception or String.
+
+* The String elements get converted to System.Management.Automation.RuntimeException,
+just as it's currently done by the "throw" statement.
+
+* The outermost System.Management.Automation.ErrorRecord gets created with the category
+"OperationStopped".
+
+* The field FullyQualifiedErrorId of this outermost error gets
+built by concatenation (with separators "`r`n") of these fields from all the nested errors
+from the argument list.  If an entry in the list is an ErrorRecord, the value for
+concatenation from it is FullyQualifiedErrorId. If an entry in the list is a bare
+Exception with possible further nesting then the Message fields from all the
+Excpetions in this chain get concatenated. This allows to both handle the bare exceptions
+and avoid the duplication of the messages in the concatenation.
+
+* The field ScriptStackTrace of this outermost error is set equal to this field
+of the innermost error (since it's the place of the original first error that is most
+deeply nested, and all thr callers will likely already be in that stack). If
+the innermost error is supplied not as an
+System.Management.Automation.ErrorRecord object but as a bare Exception object,
+the ScriptStackTrace of the deepest available ErrorRecord object is used.
+
+* The Exception objects from the whole argument list become concatenated into
+one chain.
+
+## Alternative implementations
+
+The implementation described in https://blogs.msdn.microsoft.com/sergey_babkins_blog/2016/12/30/reporting-the-nested-errors-in-powershell/
+had no way to replace the field ScriptStackTrace in the new error, so it had to
+carry the original stack as an error object. The implementation built into the
+language would have no such limitation.
+

--- a/1-Draft/RFCNNNN-Print-Stack-Trace.md
+++ b/1-Draft/RFCNNNN-Print-Stack-Trace.md
@@ -1,0 +1,57 @@
+---
+RFC: 
+Author: Sergey Babkin
+Status: Draft
+Area: Error handling
+Comments Due: 
+---
+
+# Printing the script stack trace
+
+The stack trace of an error is a very valuable development and debugging tool.
+Currently the script stack trace is available in the error objects but are not
+printed out. Providing an easy way to enable such printing would be very useful.
+
+## Motivation
+
+The decision to not print the stack trace was apparently driven by the drive for
+the reduced output clutter for the casual users. However it is a major pain point
+for the authors of the scripts.
+
+The printing of the stack trace can be added by modifying the default formatter
+for the class System.Management.Automation.ErrorRecord but it's painful and not
+widely known. It would be much more convenient to enable by setting a global variable,
+such as
+
+$PSPrintStack = $true
+
+And additional convenience of using a variable that modifies the action of the
+pre-defined formatter ather than loading a custom formatter is that it becomes
+easy to use in the remote sessions. The errors get converted to strings in the
+remote sessions before they are sent back, so the formatter of the remote machine
+is used. Loading a custom formatter there requires copying the format file
+(since the Update-FormatData command reads only from a file, not from a pipeline)
+to the remote machine and then loading it there. This is much more complicated
+than setting a variable in the remote session.
+
+## Specification
+
+In the file $PSHOME\PowerShellCore.format.ps1xml in the entry for 
+$PSHOME\PowerShellCore.format.ps1xml add one more ExpressionBinding block:
+
+<ExpressionBinding>
+    <ScriptBlock>
+        if ($PSPrintStack) { $_.ScriptStackTrace }
+    </ScriptBlock>
+</ExpressionBinding>
+
+Also, it happens that the current output of the formatter is not always properly
+terminated by a "`n", so to avoid sticking the stack trace to the end of the
+previous line, fix the preceding code to add "`n":
+
+    elseif (! $_.ErrorDetails -or ! $_.ErrorDetails.Message) {
+        $_.Exception.Message + $posmsg + "`n"  # SB-changed
+    } else {
+        $_.ErrorDetails.Message + $posmsg + "`n" # SB-changed
+    }
+

--- a/1-Draft/RFCNNNN-Print-Stack-Trace.md
+++ b/1-Draft/RFCNNNN-Print-Stack-Trace.md
@@ -39,19 +39,23 @@ than setting a variable in the remote session.
 In the file $PSHOME\PowerShellCore.format.ps1xml in the entry for 
 $PSHOME\PowerShellCore.format.ps1xml add one more ExpressionBinding block:
 
+```
 <ExpressionBinding>
     <ScriptBlock>
         if ($PSPrintStack) { $_.ScriptStackTrace }
     </ScriptBlock>
 </ExpressionBinding>
+```
 
 Also, it happens that the current output of the formatter is not always properly
-terminated by a "`n", so to avoid sticking the stack trace to the end of the
-previous line, fix the preceding code to add "`n":
+terminated by a "\`n", so to avoid sticking the stack trace to the end of the
+previous line, fix the preceding code to add "\`n":
 
+```
     elseif (! $_.ErrorDetails -or ! $_.ErrorDetails.Message) {
         $_.Exception.Message + $posmsg + "`n"  # SB-changed
     } else {
         $_.ErrorDetails.Message + $posmsg + "`n" # SB-changed
     }
+```
 


### PR DESCRIPTION
Proposals for nested errors and stack trace printing.
<!--

All new RFCs should:

* Not have a number - maintainers will assign the number
* Be placed in the Draft folder

Maintainers will sometimes need to make small edits (for example, set the RFC number).
To make this easier, we suggest giving maintainers permission to push to your fork,
see https://github.com/blog/2247-improving-collaboration-with-forks.

Also be sure to read https://github.com/PowerShell/PowerShell-RFC/blob/master/RFC0000-RFC-Process.md

-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-rfc/58)
<!-- Reviewable:end -->
