### PR TITLE
rationalizing the file encoding story for cmdlets

### DIFF
--- a/1-Draft/DefaultFileEncoding.md
+++ b/1-Draft/DefaultFileEncoding.md
@@ -62,11 +62,10 @@ The following is the complete list of `FileSystemCmdletProviderEncoding` members
 * UTF8
 * UTF8NoBOM
 
-When `$PSDefaultFileEncoding` is set to `UTF8NoBOM`, the file will be created with UTF8 encoding but a BOM will not be added.
+When `$PSDefaultFileEncoding` is set to `UTF8NoBOM`, the file shall be created with UTF8 encoding and no BOM shall be written.
 
-When `$PSDefaultFileEncoding` is set to `Legacy`, the behavior will change based on the platform:
+When `$PSDefaultFileEncoding` is set to `Legacy`, the behavior shall be:
 
-**Windows**
 ```
 CmdletName       Encoding
 ----------       --------
@@ -78,25 +77,17 @@ Set-Content      ASCII
 Export-PSSession UTF8 (with BOM)
 Redirection      UTF16
 ```
+This persists the irregular file encoding on non-Windows platforms, and allows Linux files to be used on Windows with the same encoding as exists in previous releases of PowerShell.
 
-**Non-Windows**
-```
-CmdletName       Encoding
-----------       --------
-Add-Content      UTF8 (no BOM)
-Export-Clixml    UTF8 (no BOM)
-Export-CSV       UTF8 (no BOM)
-Out-File         UTF8 (no BOM)
-Set-Content      UTF8 (no BOM)
-Export-PSSession UTF8 (no BOM)
-Redirection      UTF8 (no BOM)
-```
 The default on Windows systems shall remain unchanged (the value for `$PSDefaultFileEncoding` shall be set to `Legacy`), non-Windows platforms shall set `$PSDefaultFileEncoding` to `UTF8NoBOM`.
-If the `$PSDefaultFileEncoding` is not set, `UTF8NoBOM` shall be the default for non-Windows systems, and the current behavior (`Legacy`) on Windows.
+If the `$PSDefaultFileEncoding` is not set, `UTF8NoBOM` shall be the default for non-Windows systems, and `Legacy` (the current behavior) on Windows.
+
+Naturally, specific use of the `-encoding` parameter when invoking the cmdlet shall override `$PSDefaultFileEncoding`. 
 
 ### Exclusions
 
 Cmdlets which do not create a file are excluded from this change, so the `*-WebRequest` and `*-RestMethod` cmdlets shall not be changed.
+Only those cmdlets listed in the table above are to be changed, any other cmdlet which create files with a specific encoding are out of scope.
 Remoting protocol cmdlets shall also be unaffected with this change. 
 
 ### Optional

--- a/1-Draft/DefaultFileEncoding.md
+++ b/1-Draft/DefaultFileEncoding.md
@@ -16,30 +16,90 @@ Current PowerShell behavior is that a BOM is created by default when a file is c
 This is a problem for Linux systems where the default encoding is UTF8 but a BOM is not written when a file is created.
 Creating files on Linux with a BOM makes it difficult to interact with the native tools, as the following example illustrates.
 
-```PowerShell
+```powershell
 PS> "ĝoo" > file.txt
 PS> get-content file.txt
 ĝoo
 PS> exit
-james@jimtru-ops2:~$ cat file.txt
+james@jimtru-ops2:~$ /bin/cat file.txt
 ▒▒oo
-
 ```
+
 This is due to the BOM being written into the file:
+
 ```powershell
 PS /home/james> format-hex file.txt
 
            Path: /home/james/file.txt
            00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
 00000000   FF FE 1D 01 6F 00 6F 00 0A 00                    .þ..o.o...
+           ^^ ^^
 ```
-The native tools on Linux try to render the BOM as actual content, which harms the output.
+The native tools on Linux try to render the BOM as actual content, which results in mistranslated characters.
 If the BOM could be written when the platform expects it, interaction with native tools will be less problematic.
 
 ## Specification
 
 A new global variable `$PSDefaultFileEncoding` shall be available which allows the user to define the encoding for their system.
-The allowed values for this variable shall be defined by
+The allowed values for this variable shall be defined by the `Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding` enum, with the following additions:
+
+* UTF8NoBOM
+* Legacy
+
+The following is the complete list of `FileSystemCmdletProviderEncoding` members:
+* Ascii
+* BigEndianUnicode
+* BigEndianUTF32
+* Byte
+* Default
+* Legacy
+* Oem
+* String
+* Unicode
+* Unknown
+* UTF32
+* UTF7
+* UTF8
+* UTF8NoBOM
+
+When `$PSDefaultFileEncoding` is set to `UTF8NoBOM`, the file will be created with UTF8 encoding but a BOM will not be added.
+
+When `$PSDefaultFileEncoding` is set to `Legacy`, the behavior will change based on the platform:
+
+**Windows**
+```
+CmdletName       Encoding
+----------       --------
+Add-Content      ASCII
+Export-Clixml    UTF16
+Export-CSV       ASCII
+Out-File         UTF16
+Set-Content      ASCII
+Export-PSSession UTF8 (with BOM)
+Redirection      UTF16
+```
+
+**Non-Windows**
+```
+CmdletName       Encoding
+----------       --------
+Add-Content      UTF8 (no BOM)
+Export-Clixml    UTF8 (no BOM)
+Export-CSV       UTF8 (no BOM)
+Out-File         UTF8 (no BOM)
+Set-Content      UTF8 (no BOM)
+Export-PSSession UTF8 (no BOM)
+Redirection      UTF8 (no BOM)
+```
+The default on Windows systems shall remain unchanged (the value for `$PSDefaultFileEncoding` shall be set to `Legacy`), non-Windows platforms shall set `$PSDefaultFileEncoding` to `UTF8NoBOM`.
+If the `$PSDefaultFileEncoding` is not set, `UTF8NoBOM` shall be the default for non-Windows systems, and the current behavior (`Legacy`) on Windows.
+
+### Exclusions
+
+Cmdlets which do not create a file are excluded from this change, so the `*-WebRequest` and `*-RestMethod` cmdlets shall not be changed.
+Remoting protocol cmdlets shall also be unaffected with this change. 
+
+### Optional
 
 We should take this opportunity to rationalize our use of the `Encoding` parameter, and change the cmdlets which use Encoding as `string` or `System.Text.Encoding` type to use `Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding`.
 The following cmdlets use various types for the parameter `Encoding`
@@ -61,31 +121,68 @@ Send-MailMessage System.Text.Encoding
 Set-Content      Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding
 ``` 
 
-`Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding` shall be extended to include:
-
-* UTF8NoBOM
-
-which result in the membernames of this enum being:
-* Ascii
-* BigEndianUnicode
-* BigEndianUTF32
-* Byte
-* Default
-* Oem
-* String
-* Unicode
-* Unknown
-* UTF32
-* UTF7
-* UTF8
-* UTF8NoBOM
-
-The default on Windows systems shall remain unchanged, non-Windows platforms shall be defaulted to `UTF8NoBOM` via the `$PSDefaultFileEncoding` variable.
-If the `$PSDefaultFileEncoding` is not set, `UTF8NoBOM` shall be the default for non-Windows systems, and the current behavior () on Windows.
+It will make these cmdlets easier to maintain over time.
 
 ### Examples
+---
+Creating a file without a BOM on a Linux system (the default):
+```powershell
+PS> "ĝoo" > file.txt
+PS> get-content file.txt
+ĝoo
+PS> exit
+james@jimtru-ops2:~$ cat file.txt
+ĝoo
+```
+
+Additional details:
+```powershell
+PS /home/james> "©opyright" > c.txt
+PS /home/james> format-hex c.txt
+           Path: /home/james/c.txt
+           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
+00000000   C2 A9 6F 70 79 72 69 67 68 74 0A                 Â©opyright.
+
+PS /home/james> /bin/cat c.txt
+©opyright
+PS /home/james> get-content c.txt 
+©opyright
+PS /home/james> bash
+james@jimtru-ops2:~$ date >> c.txt
+james@jimtru-ops2:~$ cat c.txt
+©opyright
+Thu Feb 16 15:02:58 PST 2017
+james@jimtru-ops2:~$ exit
+exit
+PS /home/james> get-content -Encoding utf8 c.txt
+©opyright
+Thu Feb 16 15:02:58 PST 2017
+```
+
+Creating a file with a BOM on a Linux System, this will specifically put the BOM in the file and will render the file problematic on Linux:
+```powershell
+$PSDefaultFileEncoding = "UTF8"
+PS> "ĝoo" > file.txt
+PS> get-content file.txt
+ĝoo
+PS> exit
+james@jimtru-ops2:~$ cat file.txt
+▒▒oo
+```
+
+This mimics our current behavior and is due to the BOM being written into the file.
+This file _would_ be suitable for use on a Windows system.
+
+Creating a file without a BOM on Windows:
+```powershell
+PS> "ĝoo" |out-file -encoding UTF8NoBOM file.txt
+```
 
 ### Commentary
 
-UTF8NoBOM is, of course, not an encoding but neither are a number of the other values for `FileSystemCmdletProviderEncoding`. 
-However, it _is_ descriptive of what we are doing. 
+`UTF8NoBOM` and `Legacy` are, of course, not actual encodings but neither are a number of the other values for `FileSystemCmdletProviderEncoding`. 
+However, it is somewhat descriptive of our behavior. 
+
+### Alternate Approaches
+The setting need not be a PowerShell variable, it could be an environment variable or part of the configuration proposed by [PowerShell-StartupConfig](https://github.com/PowerShell/PowerShell-RFC/blob/master/1-Draft/RFC0015-PowerShell-StartupConfig.md).
+However, this is the simplest approach and these alternatives can be done at later time.

--- a/1-Draft/DefaultFileEncoding.md
+++ b/1-Draft/DefaultFileEncoding.md
@@ -1,0 +1,91 @@
+---
+RFC: Default File Encoding
+Author: James Truher
+Status: Draft
+Area: FileSystem
+Comments Due: 4/16/2017
+---
+
+# Default file encoding which optionally includes Byte Order Mark (BOM) 
+
+Ensuring file creation is proper for the platform, including whether the BOM should be written.
+
+## Motivation
+
+Current PowerShell behavior is that a BOM is created by default when a file is created for those encodings where the BOM is needed.
+This is a problem for Linux systems where the default encoding is UTF8 but a BOM is not written when a file is created.
+Creating files on Linux with a BOM makes it difficult to interact with the native tools, as the following example illustrates.
+
+```PowerShell
+PS> "ĝoo" > file.txt
+PS> get-content file.txt
+ĝoo
+PS> exit
+james@jimtru-ops2:~$ cat file.txt
+▒▒oo
+
+```
+This is due to the BOM being written into the file:
+```powershell
+PS /home/james> format-hex file.txt
+
+           Path: /home/james/file.txt
+           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
+00000000   FF FE 1D 01 6F 00 6F 00 0A 00                    .þ..o.o...
+```
+The native tools on Linux try to render the BOM as actual content, which harms the output.
+If the BOM could be written when the platform expects it, interaction with native tools will be less problematic.
+
+## Specification
+
+A new global variable `$PSDefaultFileEncoding` shall be available which allows the user to define the encoding for their system.
+The allowed values for this variable shall be defined by
+
+We should take this opportunity to rationalize our use of the `Encoding` parameter, and change the cmdlets which use Encoding as `string` or `System.Text.Encoding` type to use `Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding`.
+The following cmdlets use various types for the parameter `Encoding`
+
+```PowerShell
+PS> Get-Command -type cmdlet | ?{$\_.parameters} |?{$\_.source -match "microsoft"}|ft name,{$\_.parameters['encoding'].ParameterType}
+
+Name             $_.parameters['encoding'].ParameterType
+----             ---------------------------------------
+Add-Content      Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding
+Export-Clixml    System.String
+Export-Csv       System.String
+Export-PSSession System.String
+Get-Content      Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding
+Import-Csv       System.String
+Out-File         System.String
+Select-String    System.String
+Send-MailMessage System.Text.Encoding
+Set-Content      Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding
+``` 
+
+`Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding` shall be extended to include:
+
+* UTF8NoBOM
+
+which result in the membernames of this enum being:
+* Ascii
+* BigEndianUnicode
+* BigEndianUTF32
+* Byte
+* Default
+* Oem
+* String
+* Unicode
+* Unknown
+* UTF32
+* UTF7
+* UTF8
+* UTF8NoBOM
+
+The default on Windows systems shall remain unchanged, non-Windows platforms shall be defaulted to `UTF8NoBOM` via the `$PSDefaultFileEncoding` variable.
+If the `$PSDefaultFileEncoding` is not set, `UTF8NoBOM` shall be the default for non-Windows systems, and the current behavior () on Windows.
+
+### Examples
+
+### Commentary
+
+UTF8NoBOM is, of course, not an encoding but neither are a number of the other values for `FileSystemCmdletProviderEncoding`. 
+However, it _is_ descriptive of what we are doing. 


### PR DESCRIPTION
An RFC was requested in response to https://github.com/PowerShell/PowerShell/issues/707, so here it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-rfc/70)
<!-- Reviewable:end -->
