### PR TITLE
Correction of roles and workflow

### DIFF
--- a/RFC0000-RFC-Process.md
+++ b/RFC0000-RFC-Process.md
@@ -3,7 +3,7 @@ RFC: RFC0000
 Author: Steve Lee
 Status: Draft
 Area: Process
-Version: 1.3
+Version: 1.3.1
 Feedback: https://github.com/PowerShell/PowerShell-Language-RFC/issues/5
 ---
 
@@ -18,9 +18,10 @@ This process was adapted from the Chef RFC process as well as from DMTF.org proc
 
 ## Roles
 
-- **Author** - All members of the community are allowed to author new RFCs and can provide feedback to any RFC.
-- **Maintainer** - Owner of the RFC process.
-- **Maintainer's committee** - Committee of Maintainers to vote and to make conclusion about accept/reject RFC.
+* **Author**: All members of the community are allowed to author new RFCs and can provide feedback to any RFC.
+* **PowerShell Committee**: The design committe that votes to accept or reject an RFC.
+(Learn more about the PowerShell Committee [here](https://github.com/PowerShell/PowerShell/blob/master/docs/community/governance.md#powershell-committee).)
+* **Committee Member**: An individual member of the PowerShell Committee.
 
 ## RFC Naming Convention
 
@@ -40,7 +41,7 @@ Status: <Draft | Experimental | Accepted | Rejected | Withdrawn | Final>
 SupercededBy: <link to another RFC>
 Version: <Major>.<Minor>
 Area: <Area within the PowerShell language>
-Comments Due: <Date for submitting comments to current draft. Minimum 1 month>
+Comments Due: <Date for submitting comments to current draft (minimum 1 month)>
 ---
 
 # Title
@@ -67,31 +68,31 @@ RFCs go through applicable stages:
 
 This is the initial draft of a RFC posted for comments and considered a work-in-progress.
 
-New proposed drafts should be submitted as a Pull Request from Author's fork.
-Author must ensure the 'modifiable by maintainers' is checked so that the Maintainers can assign the next RFC number.
+New proposed drafts should be submitted as a Pull Request from the Author's fork.
+The Author must ensure that 'Allow edits from maintainers' is checked so that a Committee Member can assign the next RFC number.
 
-Maintainers only ensure that the RFC adheres to the template and the RFC process and then merge the PRPull Request.
+Committee Members also ensure that the RFC adheres to the template and the RFC process before merging the Pull Request.
 
-After that Maintainers will ask the Author to create an issue for this RFC and used for collection and response to comments (Author creates it so that they get notified of new comments instead of the Maintainer).
-Typically, one or two months is allowed for comments (see above `Comments Due`).
+After the Pull Request is merged, Maintainers will ask the Author to create an issue for this RFC to collect and respond to feedback on the RFC.
+(The Author should create issue so that they get notified of new comments instead of the Committee Member.)
+Typically, one or two months is allowed for comments (see `Comments Due` above).
 
-Community discuss the RFC.
+At this point, the community discusses the RFC.
 
-After `Comments Due` date the Author summarizes comments, submit new Pull Request to make the final RFC Draft and ask the Maintainer's committee to vote.
+After the `Comments Due` date, the Author summarizes the comments, submits a new Pull Request to make the final RFC Draft, and asks the PowerShell Committee to vote.
 
-Maintainers merge the Pull Request.
-
-The Maintainer's committee vote for the RFC Draft and make a conclusion: reject, return for discussion, accept.
+Just before voting, the PowerShell Comittee merges the Pull Request.
+The PowerShell Committee then votes to accept or reject the RFC Draft.
 
 * Draft-Accepted
 
-The Maintainer's committee reviewed the RFC Draft and comments, voted and accepted the RFC Draft.
+The PowerShell Committee has reviewed the RFC Draft and comments, and has voted to accept the RFC Draft.
 
-New comments are not being sought.
+At this point, new comments are not being sought.
 
-Code work has not started/planned or not needed.
+Code work has not started and is not planned or not needed.
 
-Community is invited to use and implement the RFC.
+The community is invited to implement the RFC.
 
 * Experimental
 
@@ -122,3 +123,5 @@ Added Draft-Accepted state and Version header property.
 v1.2 - 8-18-2016 - Open submitting RFCs to the community and update formatting.
 
 v1.3 - 9-26-2016 - Added Withdrawn stage.  Comments Due field to template.  Updated guidance on RFC numbering.
+
+v1.3.1 - 3-22-2017 - Cleaned up language and made explicit clarifications to process

--- a/RFC0000-RFC-Process.md
+++ b/RFC0000-RFC-Process.md
@@ -90,7 +90,7 @@ The PowerShell Committee has reviewed the RFC Draft and comments, and has voted 
 
 At this point, new comments are not being sought.
 
-Code work has not started and is not planned or not needed.
+No one has begun implementing the RFC, and there are no current plans to implement the RFC.
 
 The community is invited to implement the RFC.
 

--- a/RFC0000-RFC-Process.md
+++ b/RFC0000-RFC-Process.md
@@ -18,7 +18,9 @@ This process was adapted from the Chef RFC process as well as from DMTF.org proc
 
 ## Roles
 
-All members of the community are allowed to author new RFCs and can provide feedback to any RFC.
+- **Author** - All members of the community are allowed to author new RFCs and can provide feedback to any RFC.
+- **Maintainer** - Owner of the RFC process.
+- **Maintainer's committee** - Committee of Maintainers to vote and to make conclusion about accept/reject RFC.
 
 ## RFC Naming Convention
 
@@ -38,7 +40,7 @@ Status: <Draft | Experimental | Accepted | Rejected | Withdrawn | Final>
 SupercededBy: <link to another RFC>
 Version: <Major>.<Minor>
 Area: <Area within the PowerShell language>
-Comments Due: <Date for submitting comments to current draft>
+Comments Due: <Date for submitting comments to current draft. Minimum 1 month>
 ---
 
 # Title
@@ -64,17 +66,32 @@ RFCs go through applicable stages:
 * Draft
 
 This is the initial draft of a RFC posted for comments and considered a work-in-progress.
-New proposed drafts should be submitted as a Pull Request from your fork.
-Ensure the 'modifiable by maintainers' is checked so that the maintainers can assign the next RFC number.
-Maintainers only ensure that the RFC adheres to the template and process.
-Maintainers will ask the author to create an issue for this RFC and used for collection and response to comments (author creates it so that they get notified of new comments instead of the maintainer).
-Typically, one or two months is allowed for comments.
-When the author is ready to submit to the committee for voting, they submit a Pull Request and indicate they are ready for voting.
+
+New proposed drafts should be submitted as a Pull Request from Author's fork.
+Author must ensure the 'modifiable by maintainers' is checked so that the Maintainers can assign the next RFC number.
+
+Maintainers only ensure that the RFC adheres to the template and the RFC process and then merge the PRPull Request.
+
+After that Maintainers will ask the Author to create an issue for this RFC and used for collection and response to comments (Author creates it so that they get notified of new comments instead of the Maintainer).
+Typically, one or two months is allowed for comments (see above `Comments Due`).
+
+Community discuss the RFC.
+
+After `Comments Due` date the Author summarizes comments, submit new Pull Request to make the final RFC Draft and ask the Maintainer's committee to vote.
+
+Maintainers merge the Pull Request.
+
+The Maintainer's committee vote for the RFC Draft and make a conclusion: reject, return for discussion, accept.
 
 * Draft-Accepted
 
-Comments have been reviewed and new comments are not being sought.
+The Maintainer's committee reviewed the RFC Draft and comments, voted and accepted the RFC Draft.
+
+New comments are not being sought.
+
 Code work has not started/planned or not needed.
+
+Community is invited to use and implement the RFC.
 
 * Experimental
 


### PR DESCRIPTION
Based on my first experience. 🐔 

<!--

All new RFCs should:

* Not have a number - maintainers will assign the number
* Be placed in the Draft folder

Maintainers will sometimes need to make small edits (for example, set the RFC number).
To make this easier, we suggest giving maintainers permission to push to your fork,
see https://github.com/blog/2247-improving-collaboration-with-forks.

Also be sure to read https://github.com/PowerShell/PowerShell-RFC/blob/master/RFC0000-RFC-Process.md

-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-rfc/81)
<!-- Reviewable:end -->
