### PR TITLE
Edits to RFC0002 after committee discussion

### DIFF
--- a/1-Draft/RFC0002-Generalized-Splatting.md
+++ b/1-Draft/RFC0002-Generalized-Splatting.md
@@ -221,14 +221,6 @@ $params = @{a = 1; b = '2'; c = 3}
 [foo]::bar(0, @?$params)
 ```
 
-### Slicing operators
-
-The suggested use of '+' and '-' is perhaps surprising
-even though they correspond to Add and Remove, respectively.
-The actual operation is also similar to a union or intersection,
-so other operators should be considered, perhaps bitwise operators
-like '-bnot' and '-bor', or maybe new general purpose set operators. 
-
 ### Postfix operator
 
 The use of a sigil is not always well received.
@@ -273,3 +265,9 @@ When using '-', the result will exclude all keys from the right hand side.
 
 In either case,
 it is not an error to specify a key in the right hand side operand that is not present in the left hand side.  
+
+The suggested use of '+' and '-' is perhaps surprising
+even though they correspond to Add and Remove, respectively.
+The actual operation is also similar to a union or intersection,
+so other operators should be considered, perhaps bitwise operators
+like '-bnot' and '-bor', or maybe new general purpose set operators.

--- a/1-Draft/RFC0002-Generalized-Splatting.md
+++ b/1-Draft/RFC0002-Generalized-Splatting.md
@@ -173,15 +173,6 @@ $subStringArgs = @{startIndex = 2}
 $str.SubString(3, @$subStringArgs)
 ```
 
-Using the relaxed splatting operator, the `3` value will override the value in `$subStringArgs`:
-
-```PowerShell
-# This will not result in an error,
-# and the substring will be of length 3.
-$subStringArgs = @{startIndex = 2}
-$str.SubString(3, @?$subStringArgs)
-```
-
 Multiple splatted arguments are not allowed:
 
 ```PowerShell
@@ -196,8 +187,39 @@ The splatted argument must be last.
 $str.SubString(@@{length=2}, 2)
 ```
 
-
 ## Alternate Proposals and Considerations
+
+### Relaxed splatting in method invocations
+
+Initially, we wanted to support relaxed splatting for invocation of .NET methods.
+In this case, the `3` value would override the value in `$subStringArgs`:
+
+```PowerShell
+# This will not result in an error,
+# and the substring will be of length 3.
+$subStringArgs = @{startIndex = 2}
+$str.SubString(3, @?$subStringArgs)
+```
+
+However, some situations may make it ambiguous or unclear as to which overload you're invoking.
+
+While not a good practice for API design, if the third overload below is added at a later date,
+the meaning of the PowerShell will change when using relaxed splatting.
+
+```csharp
+class foo {
+    void static bar(int a, string b);
+    void static bar(int a, string b, int c);
+    // this third overload may be added at a later date
+    void static bar(int d, int a, string b, int c);
+}
+```
+
+```PowerShell
+$params = @{a = 1; b = '2'; c = 3}
+
+[foo]::bar(0, @?$params)
+```
 
 ### Slicing operators
 

--- a/2-Draft-Accepted/RFC0002-Generalized-Splatting.md
+++ b/2-Draft-Accepted/RFC0002-Generalized-Splatting.md
@@ -1,7 +1,7 @@
 ---
 RFC: 0002
 Author: Jason Shirk
-Status: Draft
+Status: Draft-Accepted
 Area: Splatting
 Comments Due: 3/31/2016
 Edits: Joey Aiello
@@ -271,3 +271,33 @@ even though they correspond to Add and Remove, respectively.
 The actual operation is also similar to a union or intersection,
 so other operators should be considered, perhaps bitwise operators
 like '-bnot' and '-bor', or maybe new general purpose set operators.
+
+---------------
+
+## PowerShell Committee Decision
+
+### Voting Results
+
+Joey Aiello: Accept
+
+Bruce Payette: Accept
+
+Steve Lee: Accept
+
+Hemant Mahawar: Accept
+
+Dongbo Wang: Accept
+
+Kenneth Hansen: Accept
+
+### Majority Decision
+
+Committee agrees that this is the above features would be useful to have in splatting.
+However, we do not currently have a plan to implement any of this,
+so it can be picked up by a member of the community.
+
+Also, it would be useful to build a new RFC for hashtable manipulation per the alternate considerations.
+
+### Minority Decision
+
+N/A


### PR DESCRIPTION
<!--

All new RFCs should:

* Not have a number - maintainers will assign the number
* Be placed in the Draft folder

Maintainers will sometimes need to make small edits (for example, set the RFC number).
To make this easier, we suggest giving maintainers permission to push to your fork,
see https://github.com/blog/2247-improving-collaboration-with-forks.

Also be sure to read https://github.com/PowerShell/PowerShell-RFC/blob/master/RFC0000-RFC-Process.md

-->

This includes:
* explicit override of the relaxed splatting operator (for both cmdlet and .NET method invocation)
* moved "Modifying hashtables for splatting" to the Alternate Proposals section
* a couple typo edits
