### PR TITLE
RFC to  obsolete `Send-MailMessage`

### DIFF
--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -31,7 +31,7 @@ re-implement as a separate module.
 
 ### Add a warning to 6.2 after the release of 6.2
 
-During the 6.3 development time, we will add a warning to `Send-MailMessage` that an alternative should be found.
+In a 6.2 servicing release, we will add a warning to `Send-MailMessage` that an alternative method should be found.
 
 ### Remove the cmdlet in 6.3
 

--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -43,13 +43,6 @@ In a 6.2, we have added an obsolete warning to `Send-MailMessage` that an altern
 
 **Note:** Adding an obsolete warning should not break compatibility in any way.
 
-### Positive confirmation of issue in 6.3
-
-We will add a switch requiring the user to accept the risk of using older **possibly** less secure implementations.
-This switch would be called `-AllowUnsecureConnection` and would be mandatory
-
-**Note:** The switch name is based on the [DSC Property](https://docs.microsoft.com/en-us/powershell/dsc/managing-nodes/metaconfig#configuration-server-blocks)
-
 ### If needed, develop an alternative
 
 If needed, develop a new cmdlet based on the DotNet recommended solution of [MailKit](https://github.com/jstedfast/MailKit).
@@ -66,6 +59,17 @@ Feedback on this option was negative and the RFC has been updated with then next
 
 The community could develop a replacement that can could be incorporated back into PowerShell Core.
 This has the disadvantage of increasing the size of PowerShell Core and delaying the solution.
+
+### Positive confirmation of issue in 6.3
+
+We could add a switch requiring the user to accept the risk of using older **possibly** less secure implementations.
+This switch would be called `-AllowUnsecureConnection` and would be mandatory.
+
+**Note:** The switch name is based on the [DSC Property](https://docs.microsoft.com/en-us/powershell/dsc/managing-nodes/metaconfig#configuration-server-blocks)
+
+However, given the high usage of `Send-MailMessage` in automated scenarios (like scheduled tasks),
+and the plan to work on a `MailKit` based alternative, we'd rather leave the cmdlet working as-is
+for the time being.
 
 ### Additional considerations
 

--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -9,7 +9,7 @@ Comments Due: 4/30/2019
 Plan to implement: No
 ---
 
-# Deprecating `Send-MailMessage`
+# Obsoleting `Send-MailMessage`
 
 `Send-MailMessage` does not support many modern protocols leading to the inability to use this with modern secure mail services.
 See [DotNet DE0005](https://github.com/dotnet/platform-compat/blob/master/docs/DE0005.md).
@@ -35,7 +35,7 @@ It's great for one off emails from tools, but doesn't scale to modern requiremen
     * Office365
       * https://docs.microsoft.com/en-us/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations#SendMessages
 
-## Deprecation Plan
+## Obsoletion  Plan
 
 ### Add a warning to 6.2
 

--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -19,7 +19,7 @@ re-implement as a separate module.
 
 ## Motivation
 
-    Most major mail platforms now have REST methods to send mail allowing existing cmdlets to allow sending mail.
+    Most major mail platforms now have REST methods to send mail, which allows `Invoke-RestMethod' to allow sending mail messages.
 
     * gmail
       * https://developers.google.com/gmail/api/v1/reference/users/messages/send

--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -39,7 +39,7 @@ It's great for one off emails from tools, but doesn't scale to modern requiremen
 
 ### Add a warning to 6.2
 
-In a 6.2, we will add an obsolete warning to `Send-MailMessage` that an alternative method should be found.
+In a 6.2, we have added an obsolete warning to `Send-MailMessage` that an alternative method should be found.
 
 ### Remove the cmdlet in 6.3
 

--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -19,6 +19,14 @@ re-implement as a separate module.
 
 ## Motivation
 
+### Primary
+
+The underlying API, [`SmtpClient`](https://docs.microsoft.com/dotnet/api/system.net.mail.smtpclient), doesn't support many modern protocols.
+It is compat-only.
+It's great for one off emails from tools, but doesn't scale to modern requirements of the protocol.
+
+### Secondary
+
     Most major mail platforms now have REST methods to send mail, which allows `Invoke-RestMethod' to allow sending mail messages.
 
     * gmail
@@ -29,9 +37,9 @@ re-implement as a separate module.
 
 ## Removal Plan
 
-### Add a warning to 6.2 after the release of 6.2
+### Add a warning to 6.2
 
-In a 6.2 servicing release, we will add a warning to `Send-MailMessage` that an alternative method should be found.
+In a 6.2, we will add an obsolete warning to `Send-MailMessage` that an alternative method should be found.
 
 ### Remove the cmdlet in 6.3
 
@@ -43,19 +51,29 @@ If needed, develop a new cmdlet based on the DotNet recommended solution of [Mai
 
 ## Alternate Proposals and Considerations
 
+### Alternative to removal
+
+Instead of removing the cmdlet,
+a switch could be added requiring the user to accept the risk of using older less secure implementations.
+This switch would be called `-AllowInsecure` and would be mandatory.
+
+### Community replacement
+
 The community could develop a replacement that can could be incorporated back into PowerShell Core.
 This has the disadvantage of increasing the size of PowerShell Core and delaying the solution.
 
-### GMail REST API
+### Additional considerations
+
+#### GMail REST API
 
 To use the GMail REST API the following additional items are needed
 
-### WebSafeBase64
+#### WebSafeBase64
 
 For GMail, a MIME message is required to be encoded in this format.
 https://code.google.com/p/stringencoders/wiki/WebSafeBase64
 
-### Something to compose the MIME message
+#### Something to compose the MIME message
 
 For GMail, you have to pass the MIME message.
 

--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -35,15 +35,20 @@ It's great for one off emails from tools, but doesn't scale to modern requiremen
     * Office365
       * https://docs.microsoft.com/en-us/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations#SendMessages
 
-## Removal Plan
+## Deprecation Plan
 
 ### Add a warning to 6.2
 
 In a 6.2, we have added an obsolete warning to `Send-MailMessage` that an alternative method should be found.
 
-### Remove the cmdlet in 6.3
+**Note:** Adding an obsolete warning should not break compatibility in any way.
 
-During the development of 6.3, remove the `Send-MailMessage` cmdlet.
+### Positive confirmation of issue in 6.3
+
+We will add a switch requiring the user to accept the risk of using older **possibly** less secure implementations.
+This switch would be called `-AllowUnsecureConnection` and would be mandatory
+
+**Note:** The switch name is based on the [DSC Property](https://docs.microsoft.com/en-us/powershell/dsc/managing-nodes/metaconfig#configuration-server-blocks)
 
 ### If needed, develop an alternative
 
@@ -51,11 +56,11 @@ If needed, develop a new cmdlet based on the DotNet recommended solution of [Mai
 
 ## Alternate Proposals and Considerations
 
-### Alternative to removal
+### Remove the cmdlet during 6.3
 
-Instead of removing the cmdlet,
-a switch could be added requiring the user to accept the risk of using older less secure implementations.
-This switch would be called `-AllowInsecure` and would be mandatory.
+During the development of 6.3, remove the `Send-MailMessage` cmdlet.
+
+Feedback on this option was negative and the RFC has been updated with then next most reasonable option.
 
 ### Community replacement
 

--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -27,7 +27,7 @@ It's great for one off emails from tools, but doesn't scale to modern requiremen
 
 ### Secondary
 
-    Most major mail platforms now have REST methods to send mail, which allows `Invoke-RestMethod' to allow sending mail messages.
+    Most major mail platforms now have REST methods to send mail, which allows `Invoke-RestMethod` to allow sending mail messages.
 
     * gmail
       * https://developers.google.com/gmail/api/v1/reference/users/messages/send

--- a/1-Draft/RFCXXXX-Send-MailMessage.md
+++ b/1-Draft/RFCXXXX-Send-MailMessage.md
@@ -1,0 +1,72 @@
+---
+RFC: RFCXXXX
+Author: Travis Plunk
+Status: Draft
+SupercededBy: N/A
+Version: 1.0
+Area: cmdlets
+Comments Due: 4/30/2019
+Plan to implement: No
+---
+
+# Deprecating `Send-MailMessage`
+
+`Send-MailMessage` does not support many modern protocols leading to the inability to use this with modern secure mail services.
+See [DotNet DE0005](https://github.com/dotnet/platform-compat/blob/master/docs/DE0005.md).
+Since the protocols it uses are no longer considered secure, the cmdlet as is should not be used.
+I recommend that we implement a plan to remove the cmdlet from powershell core and, if needed,
+re-implement as a separate module.
+
+## Motivation
+
+    Most major mail platforms now have REST methods to send mail allowing existing cmdlets to allow sending mail.
+
+    * gmail
+      * https://developers.google.com/gmail/api/v1/reference/users/messages/send
+      * https://stackoverflow.com/questions/24460422/how-to-send-a-message-successfully-using-the-new-gmail-rest-api
+    * Office365
+      * https://docs.microsoft.com/en-us/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations#SendMessages
+
+## Removal Plan
+
+### Add a warning to 6.2 after the release of 6.2
+
+During the 6.3 development time, we will add a warning to `Send-MailMessage` that an alternative should be found.
+
+### Remove the cmdlet in 6.3
+
+During the development of 6.3, remove the `Send-MailMessage` cmdlet.
+
+### If needed, develop an alternative
+
+If needed, develop a new cmdlet based on the DotNet recommended solution of [MailKit](https://github.com/jstedfast/MailKit).
+
+## Alternate Proposals and Considerations
+
+The community could develop a replacement that can could be incorporated back into PowerShell Core.
+This has the disadvantage of increasing the size of PowerShell Core and delaying the solution.
+
+### GMail REST API
+
+To use the GMail REST API the following additional items are needed
+
+### WebSafeBase64
+
+For GMail, a MIME message is required to be encoded in this format.
+https://code.google.com/p/stringencoders/wiki/WebSafeBase64
+
+### Something to compose the MIME message
+
+For GMail, you have to pass the MIME message.
+
+---------------
+
+## PowerShell Committee Decision
+
+### Voting Results
+
+### Majority Decision
+
+### Minority Decision
+
+N/A

--- a/5-Final/RFC0042-Send-MailMessage.md
+++ b/5-Final/RFC0042-Send-MailMessage.md
@@ -1,7 +1,7 @@
 ---
-RFC: RFCXXXX
+RFC: RFC0042
 Author: Travis Plunk
-Status: Draft
+Status: Final
 SupercededBy: N/A
 Version: 1.0
 Area: cmdlets
@@ -85,15 +85,3 @@ https://code.google.com/p/stringencoders/wiki/WebSafeBase64
 #### Something to compose the MIME message
 
 For GMail, you have to pass the MIME message.
-
----------------
-
-## PowerShell Committee Decision
-
-### Voting Results
-
-### Majority Decision
-
-### Minority Decision
-
-N/A


### PR DESCRIPTION
<!--

All new RFCs should:

* Not have a number - maintainers will assign the number
* Be placed in the Draft folder

Maintainers will sometimes need to make small edits (for example, set the RFC number).
To make this easier, we suggest giving maintainers permission to push to your fork,
see https://github.com/blog/2247-improving-collaboration-with-forks.

Also be sure to read https://github.com/PowerShell/PowerShell-RFC/blob/master/RFC0000-RFC-Process.md

-->

