### PR TITLE
Support notification on `pwsh` startup when a new update is available

### DIFF
--- a/1-Draft/RFCNNNN-Notification-On-Version-Update.md
+++ b/1-Draft/RFCNNNN-Notification-On-Version-Update.md
@@ -22,6 +22,8 @@ It would be convenient if `pwsh` itself can notify the user of a new update on s
 
 ## Specification
 
+This feature is in the PowerShell console host, not in the PowerShell engine.
+
 ### Target Goals
 
 1. No notification or update check when the running `pwsh` is a self-built version.
@@ -297,3 +299,6 @@ This would reduce the number of helper files in the cache folder,
 however, with the cost of additional work at startup time for all versions of `pwsh`.
 Especially, for the latest stable or preview `pwsh` in use, it also needs to spend those extra cycles when it should not.
 Besides, I think having the helper files isolated in a version folder makes it flexible in case we need to make change to the design at a later time.
+
+We may consider to add an API in PowerShell engine to check for updates in future,
+so that other hosts can offer similar features using the API.

--- a/1-Draft/RFCNNNN-Notification-On-Version-Update.md
+++ b/1-Draft/RFCNNNN-Notification-On-Version-Update.md
@@ -51,7 +51,7 @@ And subsequent checks can be avoided for a reasonable period of time, such as a 
 such as when `pwsh` is in a container image.
 Hence, you should be able to suppress them altogether by setting an environment variable.
 
-### No Goals
+### Non-Goals
 
 1. Notification shows up right after a new version of `pwsh` is released.
 

--- a/1-Draft/RFCNNNN-Notification-On-Version-Update.md
+++ b/1-Draft/RFCNNNN-Notification-On-Version-Update.md
@@ -158,8 +158,8 @@ In this way, the update information for different versions of `pwsh` doesn't int
 #### How to synchronize update checks
 
 The most challenging part is to properly synchronize the update checks started from different `pwsh` processes,
-so that for a specific version of `pwsh` and a specific notification type,
-only one update check task, at most, will run to complete per a day.
+**so that for a specific version of `pwsh` and a specific notification type,
+only one update check task, at most, will run to complete per a day.**
 Other tasks should be able to detect "a check is in progress" or "the check has been done for today" and bail out early,
 to avoid any unnecessary network IO or CPU cycles.
 

--- a/1-Draft/RFCNNNN-Notification-On-Version-Update.md
+++ b/1-Draft/RFCNNNN-Notification-On-Version-Update.md
@@ -279,6 +279,7 @@ This is comparatively the easy part.
 - Run `Directory.EnumerateFiles` with the the version directory and the pattern `update<notification-type>_v*.*.*_????-??-??` to find such a file.
 - If a file path is returned, then get the version information from the file name.
 - Use that version to construct the notification message, including the URL to that GitHub release page.
+- The notification message is printed with the foreground and background colors inverted.
 
 ## Alternate Proposals and Considerations
 

--- a/1-Draft/RFCNNNN-Notification-On-Version-Update.md
+++ b/1-Draft/RFCNNNN-Notification-On-Version-Update.md
@@ -37,7 +37,7 @@ This means the check for update must not happen during `pwsh` startup.
 The only acceptable extra overhead to the `pwsh` startup should just be the work related to printing the notification.
 
 4. Check for updates should not blindly run for every interactive `pwsh` session.
-For a particular version of `pwsh`, only one check at most can run to complete per a day
+For a particular version of `pwsh`, only one check at most can run to complete per day
 no matter how many interactive session of the `pwsh` are started/opened in that day.
 
 5. After a new update is detected during a successful check,

--- a/1-Draft/RFCNNNN-Notification-On-Version-Update.md
+++ b/1-Draft/RFCNNNN-Notification-On-Version-Update.md
@@ -82,6 +82,7 @@ This section talks about
 - how to synchronize update checks from different processes of the same version `pwsh` so that at most only one can run to complete during a day
 - how to do the update check
 - how to display the notification
+- how to control the update notification behavior using an environment variable
 
 #### When to do the update check
 
@@ -240,6 +241,19 @@ This is comparatively the easy part.
 - Run `Directory.EnumerateFiles` with the the version directory and the pattern `_update_v*.*.*_????-??-??` to find such a file.
 - If a file path is returned, then get the version information from the file name.
 - Use that version to construct the notification message, including the URL to that GitHub release page.
+
+#### How to control the update notification behavior using an environment variable
+
+The environment variable `POWERSHELL_UPDATECHECK` will be introduced to control the behavior of the update notification feature.
+The environment variable supports 3 values:
+
+- `Default`. This gives you the default behaviors:
+  - `pwsh` of preview versions check for the new preview version as well as the new GA version.
+  - `pwsh` of GA versions check for the new GA version only.
+
+- `Off`. This turns off the update notification feature.
+
+- `LTS`. `pwsh` of both preview and stable versions check for the new LTS GA version only.
 
 ## Alternate Proposals and Considerations
 

--- a/5-Final/RFC0052-Notification-On-Version-Update.md
+++ b/5-Final/RFC0052-Notification-On-Version-Update.md
@@ -1,7 +1,7 @@
 ---
-RFC: RFCXXXX
+RFC: 0052
 Author: Dongbo Wang
-Status: Draft
+Status: Final
 SupercededBy: N/A
 Version: 1.0
 Area: Console


### PR DESCRIPTION
Support notification on `pwsh` startup when a new update is available.

Today, to find out whether a new version of PowerShell is available, one has to check the release page of the `PowerShell\PowerShell` repository, or depend on communication channels like `twitter` or `GitHub Notifications`. It would be convenient if `pwsh` itself can notify the user of a new update on startup.