### PR TITLE
PowerShell Core Policy

### DIFF
--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -1,0 +1,236 @@
+---
+RFC:  RFCnnnn
+Author:  travisez13
+Status:  Draft
+SupercededBy:  N/A
+Version: 0.1
+Area: Engine
+Comments Due: 6/30/2019
+---
+
+# `PowerShell Core` Policy
+
+## Motivation
+
+Consumers, developers, and enterprise system administrators should be able to flexibly and reliable way to configure PowerShell 7.
+
+## Acknowledgement
+
+I based this off of @iSazonov 's RFC, for just a slightly different purpose.
+[PR #111](https://github.com/PowerShell/PowerShell-RFC/pull/111)
+
+## Specification
+
+`PowerShell 7` should be configured using the following schemes:
+
+- On Windows - Group Policy Objects (GPO), Group Policy Preferences (GPP) and settings files.
+- On Unix - settings files.
+
+The settings files have `JSON` format.
+
+**Warning** The settings files differ from `PowerShell 7` _profile_ files, which are PowerShell scripts run at startup.
+
+Configuration schemes allow to customize `PowerShell 7` in the most flexible way:
+
+- Enterprise system administrators can use GPO,
+    GPP and computer-wide settings files to apply approved configuration settings and mandatory security settings in a centralized manner.
+    The same settings can be applied at user, application or startup levels.
+- Developers and consumers can use user, application and startup level settings files.
+
+### Configuration defaults
+
+PowerShell 7 has hard-coded defaults for all configuration options.
+
+The default values must be `secure-by-default`.
+
+For release versions hard-coded defaults must be the same as ones in re-installed configuration files. For preview versions they may vary (ex., enable experimental features and so on).
+
+If during startup PowerShell 7 cannot read system configuration files it fails to startup.
+
+If during startup PowerShell 7 cannot read user configuration files it uses _hardcoded_ defaults.
+
+If during operation PowerShell 7 cannot read configuration files it continue to use _current_ (runtime) configuration values.
+
+### Settings locations
+
+`PowerShell 7` settings are grouped into `Policy settings` and `Regular settings`.
+Regular settings are normal configuration settings.
+Regular settings can be treated as default values.
+Policy settings is high priority and overlap regular settings.
+Policy settings are used by administrators to centrally manage applications.
+
+| Location     | Policy settings                                           | Regular settings                                           |
+|--------------|-----------------------------------------------------------|------------------------------------------------------------|
+| File section | "PowerShell": { "PolicySettings": {...} }                 | "PowerShell": { "RegularSettings": {...} }                 |
+| File section | "OtherPowerShellApplication": { "PolicySettings": {...} } | "OtherPowerShellApplication": { "RegularSettings": {...} } |
+| Registry key | Software\Policies\PowerShellCore                          | Software\PowerShellCore                                    |
+
+### Policy settings Setting Fall-Back
+
+#### Motivation - Policy Setting Fall-Back
+
+This is to allow Fall-back to Windows PowerShell policies.
+
+#### Implementation
+
+For Policy Settings,
+each policy should have a `Use Windows PowerShell Policy` which will indicate that the policy should the read from
+`SOFTWARE\Policies\Microsoft\Windows\PowerShell` instead of `Software\Policies\PowerShellCore`.
+
+### Precedence of applying settings
+
+Because a configuration setting can be in several schemes, the setting wins according to the priority of its scheme.
+
+#### Precedence for Policy settings in descending order
+
+| Scheme                      | Windows                                              | Unix                                                 |
+|-----------------------------|------------------------------------------------------|------------------------------------------------------|
+| GPO -> Computer Policy      | HKLM\Software\Policies\PowerShellCore                | /etc/powershell.config.json                          |
+| GPO -> User Policy          | HKCU\Software\Policies\PowerShellCore                | See `Comment A` below                                |
+| File -> Computer-Wide       | %ProgramFiles%/PowerShell/powershell.config.json     | /opt/Microsoft/powershell/powershell.config.json     |
+| File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
+| File -> User-Wide           | %APPDATA%/powershell.config.json                     | %XDG_CONFIG_HOME%/powershell.config.json             |
+| File -> Application-Wide    | $apphome/powershell.config.json                      | $apphome/powershell.config.json                      |
+
+Defaults:
+
+`%APPDATA%` - `C:\Users\useraccount\AppData\Roaming`
+
+`%XDG_CONFIG_HOME%` - `HOME/.config`
+
+#### Parameter `-settingsfile`
+
+With `-settingsfile` parameter users can assign custom settings from the config file and overwrite user-wide and application-wide settings.
+
+##### Computer-wide and user policy settings
+
+**No** user can overwrite computer-wide and user policy settings using `-settingsfile`
+
+#### Priorities for Regular settings in descending order
+
+| Scheme                      | Windows                                              | Unix                                                 |
+|-----------------------------|------------------------------------------------------|------------------------------------------------------|
+| File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
+| File -> Application-Wide    | $apphome\powershell.config.json                      | $apphome/powershell.config.json                      |
+| File -> User-Wide           | %APPDATA%\powershell.config.json                     | ~/powershell.config.json                             |
+| File -> Computer-Wide       | %ProgramFiles%\PowerShell\powershell.config.json     | /opt/Microsoft/powershell/powershell.config.json     |
+| GPO -> User Config          | HKCU\Software\PowerShellCore                         | See `Comment A` below                                |
+| GPO -> Computer Config      | HKLM\Software\PowerShellCore                         | /etc/powershell.config.json                          |
+
+### Configuration settings
+
+A set of configuration settings in GPO scheme and file scheme for policy settings and regular settings is the same. This allows to discover and configure settings in the simplest and fastest way.
+
+#### Registry keys and settings
+
+| Key                              | SubKey                      | Option                             | Type   | Precedence          |
+|----------------------------------|-----------------------------|------------------------------------|--------|---------------------|
+| Software\Policies\PowerShellCore | -                           | -                                  |        |                     |
+| Software\PowerShellCore          | -                           | -                                  |        |                     |
+|                                  |                             | ExecutionPolicy                    | String | Computer, Then User |
+|                                  | ConsoleSessionConfiguration | EnableConsoleSessionConfiguration  | DWORD  | User, then Computer |
+|                                  | ConsoleSessionConfiguration | ConsoleSessionConfigurationName    | String | User, then Computer |
+|                                  | ModuleLogging               | EnableModuleLogging                | DWORD  | Computer, Then User |
+|                                  | ModuleLogging               | ModuleNames                        | String | Computer, Then User |
+|                                  | ProtectedEventLogging       | EncryptionCertificate              | DWORD  | Computer Wide       |
+|                                  | ScriptBlockLogging          | EnableScriptBlockInvocationLogging | DWORD  | Computer, Then User |
+|                                  | ScriptBlockLogging          | EnableScriptBlockLogging           | DWORD  | Computer, Then User |
+|                                  | Transcription               | EnableTranscripting                | DWORD  | Computer, Then User |
+|                                  | Transcription               | EnableInvocationHeader             | DWORD  | Computer, Then User |
+|                                  | Transcription               | OutputDirectory                    | String | Computer, Then User |
+|                                  | UpdatableHelp               | DefaultSourcePath                  | String | Computer Wide       |
+
+#### JSON file settings format
+
+```json
+{
+  "PowerShell": {
+    "RegularSettings": {
+      "ConsoleSessionConfiguration": {
+        "EnableConsoleSessionConfiguration": true,
+        "ConsoleSessionConfigurationName": "name"
+      },
+      "ProtectedEventLogging": {
+        "EnableProtectedEventLogging": false,
+        "EncryptionCertificate": [
+          "Joe"
+        ]
+      },
+      "ScriptBlockLogging": {
+        "EnableScriptBlockInvocationLogging": true,
+        "EnableScriptBlockLogging": false
+      },
+      "ScriptExecution": {
+        "ExecutionPolicy": "RemoteSigned",
+        "PipelineMaxStackSizeMB": 10
+      },
+      "Transcription": {
+        "EnableTranscripting": true,
+        "EnableInvocationHeader": true,
+        "OutputDirectory": "c:\\tmp"
+      },
+      "UpdatableHelp": {
+        "DefaultSourcePath": "f:\\temp"
+      }
+    },
+
+    "PoliciesSettings": {
+      ...
+    }
+  },
+
+  "OtherPowerShellApplication": {
+    "RegularSettings": {
+      ...
+    },
+    "PolicySettings": {
+      ...
+    }
+}
+```
+
+## Alternate Proposals and Considerations
+
+### Automatically resolve Windows PowerShell policy conflicts
+
+We could attempt to resolve policy conflicts between PowerShell 7 policy and Windows PowerShell policy.
+This would make the `Precedence for Policy settings` not just a simple list but a complex set of rules that would not be easily understood.  See [this conversation](https://github.com/PowerShell/PowerShell/issues/9309?#issuecomment-480643922).
+
+### Allow admins to overwrite computer-wide settings
+
+In System Lock-down mode, we attempt to protect from the admin,
+so allowing computer-wide or policy setting to be overwritten at the command-line is dangerous.
+
+We could try to check for System Lock-down mode and
+admin user and allow `-settingsfile` to overwrite computer-wide settings.
+
+But, performing the system lock-down check this early would hurt startup performance.
+
+I don't recommend this approach.
+
+### Comment A
+
+Mainly for Unix we'd add `Users` section to computer wide JSON file (`/etc/powershell.config.json`) to allow administrators set policies and regular settings on user level base
+
+```json
+{
+  "PowerShell": {
+    "RegularSettings": {
+      ...
+    },
+    "PolicySettings": {
+      ...
+    },
+  "Users": {
+    "Smith": {
+      "PowerShell": {
+        "RegularSettings": {
+          ...
+        },
+        "PolicySettings": {
+          ...
+        }
+      }
+  }
+}
+```

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -88,7 +88,7 @@ Policy settings are used by administrators to centrally manage PowerShell.
 
 #### Motivation - Policy Setting Fall-Back
 
-This is to allow fall-back to Windows PowerShell policies.
+Help to transition from Windows PowerShell to PowerShell 7.
 
 #### Implementation
 

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -82,7 +82,7 @@ Policy settings are used by administrators to centrally manage PowerShell.
 | Location     | Policy settings                                           | Regular settings                                           |
 |--------------|-----------------------------------------------------------|------------------------------------------------------------|
 | File section | "PowerShell": { "PolicySettings": {...} }                 | "PowerShell": { "RegularSettings": {...} }                 |
-| Registry key | Software\Policies\PowerShellCore                          | Software\PowerShellCore                                    |
+| Registry key | Software\Policies\PowerShellCore                          | Not Applicable                                             |
 
 ### Policy settings Setting Fall-Back
 
@@ -101,14 +101,16 @@ The default in Group Policy is to have no policy, so it would not fall back to W
 
 Because a configuration setting can be in several schemes, the setting wins according to the priority of its scheme.
 
-#### Precedence for Policy settings in descending order
+#### Precedence for Computer-Wide settings in descending order
+
+Note, this is listed as `Computer, Then User` in [Registry keys and settings](#registry-keys-and-settings).
 
 | Scheme                      | Windows                                              | Unix                                                 |
 |-----------------------------|------------------------------------------------------|------------------------------------------------------|
 | GPO -> Computer Policy      | HKLM\Software\Policies\PowerShellCore                | See [Moving configuration out of PSHome][moving]     |
 | GPO -> User Policy          | HKCU\Software\Policies\PowerShellCore                | %XDG_CONFIG_HOME%/powershell.config.json             |
-| File -> Computer-Wide       | See [Moving configuration out of PSHome][moving]     | [Moving configuration out of PSHome][moving]         |
 | File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
+| File -> Computer-Wide       | See [Moving configuration out of PSHome][moving]     | [Moving configuration out of PSHome][moving]         |
 | File -> User-Wide           | %APPDATA%/powershell.config.json                     | %XDG_CONFIG_HOME%/powershell.config.json             |
 
 Defaults:
@@ -135,15 +137,27 @@ only when not in System Lock-down mode.
 
 This will have performance impact on startup, but only when `-settingsfile` is specified.
 
-#### Precedence for Regular settings in descending order
+#### Precedence for User settings in descending order
+
+Note, this is listed as `User, then Computer` in [Registry keys and settings](#registry-keys-and-settings).
 
 | Scheme                      | Windows                                              | Unix                                                 |
 |-----------------------------|------------------------------------------------------|------------------------------------------------------|
+| GPO -> User Config          | HKCU\Software\PowerShellCore                         | %XDG_CONFIG_HOME%/powershell.config.json             |
+| GPO -> Computer Config      | HKLM\Software\PowerShellCore                         | /etc/powershell.config.json                          |
 | File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
 | File -> User-Wide           | %APPDATA%\powershell.config.json                     | %XDG_CONFIG_HOME%/powershell.config.json             |
 | File -> Computer-Wide       | See [Moving configuration out of PSHome][moving]     | /opt/Microsoft/powershell/powershell.config.json     |
-| GPO -> User Config          | HKCU\Software\PowerShellCore                         | %XDG_CONFIG_HOME%/powershell.config.json             |
+
+#### Precedence for UpdatableHelp in descending order
+
+Note, this is listed as `Computer` in [Registry keys and settings](#registry-keys-and-settings).
+
+| Scheme                      | Windows                                              | Unix                                                 |
+|-----------------------------|------------------------------------------------------|------------------------------------------------------|
 | GPO -> Computer Config      | HKLM\Software\PowerShellCore                         | /etc/powershell.config.json                          |
+| File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
+| File -> Computer-Wide       | See [Moving configuration out of PSHome][moving]     | /opt/Microsoft/powershell/powershell.config.json     |
 
 ### Configuration settings
 
@@ -151,22 +165,27 @@ A set of configuration settings in GPO scheme and file scheme for policy setting
 
 #### Registry keys and settings
 
-| Key                              | SubKey                      | Option                             | Type   | Precedence          |
-|----------------------------------|-----------------------------|------------------------------------|--------|---------------------|
-| Software\Policies\PowerShellCore | -                           | -                                  |        |                     |
-| Software\PowerShellCore          | -                           | -                                  |        |                     |
-|                                  |                             | ExecutionPolicy                    | String | Computer, Then User |
-|                                  | ConsoleSessionConfiguration | EnableConsoleSessionConfiguration  | DWORD  | User, then Computer |
-|                                  | ConsoleSessionConfiguration | ConsoleSessionConfigurationName    | String | User, then Computer |
-|                                  | ModuleLogging               | EnableModuleLogging                | DWORD  | Computer, Then User |
-|                                  | ModuleLogging               | ModuleNames                        | String | Computer, Then User |
-|                                  | ProtectedEventLogging       | EncryptionCertificate              | DWORD  | Computer Wide       |
-|                                  | ScriptBlockLogging          | EnableScriptBlockInvocationLogging | DWORD  | Computer, Then User |
-|                                  | ScriptBlockLogging          | EnableScriptBlockLogging           | DWORD  | Computer, Then User |
-|                                  | Transcription               | EnableTranscripting                | DWORD  | Computer, Then User |
-|                                  | Transcription               | EnableInvocationHeader             | DWORD  | Computer, Then User |
-|                                  | Transcription               | OutputDirectory                    | String | Computer, Then User |
-|                                  | UpdatableHelp               | DefaultSourcePath                  | String | Computer Wide       |
+Notes:
+
+- All policies are in `Software\Policies\PowerShellCore`.
+- `ExecutionPolicy` is not in any SubKey.
+
+| SubKey                      | Option                             | Type   | Precedence          |
+|-----------------------------|------------------------------------|--------|---------------------|
+| -                           | -                                  |        |                     |
+| -                           | -                                  |        |                     |
+|                             | ExecutionPolicy                    | String | Computer, Then User |
+| ConsoleSessionConfiguration | EnableConsoleSessionConfiguration  | DWORD  | User, then Computer |
+| ConsoleSessionConfiguration | ConsoleSessionConfigurationName    | String | User, then Computer |
+| ModuleLogging               | EnableModuleLogging                | DWORD  | Computer, Then User |
+| ModuleLogging               | ModuleNames                        | String | Computer, Then User |
+| ProtectedEventLogging       | EncryptionCertificate              | DWORD  | Computer Wide       |
+| ScriptBlockLogging          | EnableScriptBlockInvocationLogging | DWORD  | Computer, Then User |
+| ScriptBlockLogging          | EnableScriptBlockLogging           | DWORD  | Computer, Then User |
+| Transcription               | EnableTranscripting                | DWORD  | Computer, Then User |
+| Transcription               | EnableInvocationHeader             | DWORD  | Computer, Then User |
+| Transcription               | OutputDirectory                    | String | Computer, Then User |
+| UpdatableHelp               | DefaultSourcePath                  | String | Computer Wide       |
 
 I filed [#9632](https://github.com/PowerShell/PowerShell/issues/9632) on UpdatableHelp-DefaultSourcePath to make it allow User settings.
 
@@ -236,3 +255,7 @@ Per issues [9278](https://github.com/PowerShell/PowerShell/issues/9278) we need 
 follow that issue for issues related to new locations of files.
 
 [moving]:#moving-configuration-out-of-pshome
+
+### Allowing Regular settings from the registry in Windows
+
+This is out of scope of this RFCs

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -144,7 +144,7 @@ Note, this is listed as `User, then Computer` in [Registry keys and settings](#r
 | Scheme                      | Windows                                              | Unix                                                 |
 |-----------------------------|------------------------------------------------------|------------------------------------------------------|
 | GPO -> User Config          | HKCU\Software\PowerShellCore                         | %XDG_CONFIG_HOME%/powershell.config.json             |
-| GPO -> Computer Config      | HKLM\Software\PowerShellCore                         | /etc/powershell.config.json                          |
+| GPO -> Computer Config      | HKLM\Software\PowerShellCore                         |  See [Moving configuration out of PSHome][moving]                          |
 | File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
 | File -> User-Wide           | %APPDATA%\powershell.config.json                     | %XDG_CONFIG_HOME%/powershell.config.json             |
 | File -> Computer-Wide       | See [Moving configuration out of PSHome][moving]     | /opt/Microsoft/powershell/powershell.config.json     |
@@ -155,7 +155,7 @@ Note, this is listed as `Computer` in [Registry keys and settings](#registry-key
 
 | Scheme                      | Windows                                              | Unix                                                 |
 |-----------------------------|------------------------------------------------------|------------------------------------------------------|
-| GPO -> Computer Config      | HKLM\Software\PowerShellCore                         | /etc/powershell.config.json                          |
+| GPO -> Computer Config      | HKLM\Software\PowerShellCore                         |  See [Moving configuration out of PSHome][moving]                          |
 | File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
 | File -> Computer-Wide       | See [Moving configuration out of PSHome][moving]     | /opt/Microsoft/powershell/powershell.config.json     |
 

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -104,7 +104,10 @@ With `-settingsfile` parameter users can assign custom settings from the config 
 
 ##### Computer-wide and user policy settings
 
-**No** user can overwrite computer-wide and user policy settings using `-settingsfile`
+Admin/root users can overwrite computer-wide and user policy settings using `-settingsfile`,
+only when not in System Lock-down mode.
+
+This will have performance impact on startup, but only when `-settingsfile` is specified.
 
 #### Priorities for Regular settings in descending order
 
@@ -139,6 +142,8 @@ A set of configuration settings in GPO scheme and file scheme for policy setting
 |                                  | Transcription               | EnableInvocationHeader             | DWORD  | Computer, Then User |
 |                                  | Transcription               | OutputDirectory                    | String | Computer, Then User |
 |                                  | UpdatableHelp               | DefaultSourcePath                  | String | Computer Wide       |
+
+I filed [#9632](https://github.com/PowerShell/PowerShell/issues/9632) on UpdatableHelp-DefaultSourcePath to make it allow User settings.
 
 #### JSON file settings format
 
@@ -196,17 +201,10 @@ A set of configuration settings in GPO scheme and file scheme for policy setting
 We could attempt to resolve policy conflicts between PowerShell 7 policy and Windows PowerShell policy.
 This would make the `Precedence for Policy settings` not just a simple list but a complex set of rules that would not be easily understood.  See [this conversation](https://github.com/PowerShell/PowerShell/issues/9309?#issuecomment-480643922).
 
-### Allow admins to overwrite computer-wide settings
+### Allowing environment variable in the JSON
 
-In System Lock-down mode, we attempt to protect from the admin,
-so allowing computer-wide or policy setting to be overwritten at the command-line is dangerous.
-
-We could try to check for System Lock-down mode and
-admin user and allow `-settingsfile` to overwrite computer-wide settings.
-
-But, performing the system lock-down check this early would hurt startup performance.
-
-I don't recommend this approach.
+A new RFC should be drafted about how to allow environment variables in the JSON.
+This would allow consistent files across platforms.
 
 ### Comment A
 

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -60,8 +60,11 @@ For release versions hard-coded defaults must be the same as ones in pre-install
 
 Computer-wide configuration includes security sensitive setting,
 and failing to read those setting, for example if the file is locked or corrupted, could result in an insecure system.
-So, if during startup, PowerShell 7 cannot read files read from the Computer-Wide scope,
+So, if during startup, PowerShell 7 cannot read settings files from the Computer-Wide scope,
 it fails to startup.
+Because registry reads are more atomic,
+this is not an issue for group policy settings,
+but if we faced the same issues for these settings the solution would be the similar.
 
 If during startup PowerShell 7 cannot read user configuration files it uses _hardcoded_ defaults.
 
@@ -103,7 +106,7 @@ Because a configuration setting can be in several schemes, the setting wins acco
 | Scheme                      | Windows                                              | Unix                                                 |
 |-----------------------------|------------------------------------------------------|------------------------------------------------------|
 | GPO -> Computer Policy      | HKLM\Software\Policies\PowerShellCore                | See [Moving configuration out of PSHome][moving]     |
-| GPO -> User Policy          | HKCU\Software\Policies\PowerShellCore                | See [`Comment A`](#comment-a) below                  |
+| GPO -> User Policy          | HKCU\Software\Policies\PowerShellCore                | %XDG_CONFIG_HOME%/powershell.config.json             |
 | File -> Computer-Wide       | See [Moving configuration out of PSHome][moving]     | [Moving configuration out of PSHome][moving]         |
 | File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
 | File -> User-Wide           | %APPDATA%/powershell.config.json                     | %XDG_CONFIG_HOME%/powershell.config.json             |
@@ -132,14 +135,14 @@ only when not in System Lock-down mode.
 
 This will have performance impact on startup, but only when `-settingsfile` is specified.
 
-#### Priorities for Regular settings in descending order
+#### Precedence for Regular settings in descending order
 
 | Scheme                      | Windows                                              | Unix                                                 |
 |-----------------------------|------------------------------------------------------|------------------------------------------------------|
 | File -> Application-Startup | pwsh -settingsfile `somepath/powershell.config.json` | pwsh -settingsfile `somepath/powershell.config.json` |
-| File -> User-Wide           | %APPDATA%\powershell.config.json                     | ~/.config/powershell/powershell.config.json          |
-| File -> Computer-Wide       | %ProgramFiles%\PowerShell\powershell.config.json     | /opt/Microsoft/powershell/powershell.config.json     |
-| GPO -> User Config          | HKCU\Software\PowerShellCore                         | ~/.config/powershell/powershell.config.json|         |
+| File -> User-Wide           | %APPDATA%\powershell.config.json                     | %XDG_CONFIG_HOME%/powershell.config.json             |
+| File -> Computer-Wide       | See [Moving configuration out of PSHome][moving]     | /opt/Microsoft/powershell/powershell.config.json     |
+| GPO -> User Config          | HKCU\Software\PowerShellCore                         | %XDG_CONFIG_HOME%/powershell.config.json             |
 | GPO -> Computer Config      | HKLM\Software\PowerShellCore                         | /etc/powershell.config.json                          |
 
 ### Configuration settings

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -67,7 +67,7 @@ Because registry reads are more atomic,
 this is not an issue for group policy settings,
 but if we faced the same issues for these settings the solution would be the similar.
 
-If during startup PowerShell 7 cannot read user configuration files it uses _hardcoded_ defaults.
+If during startup PowerShell 7 cannot read user configuration files it uses _hardcoded_ defaults and emits a warning.
 
 PowerShell 7 does not update configuration values from modified configuration files during a given session after the configuration has been loaded.
 

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -45,7 +45,7 @@ The settings files have `JSON` format.
 Configuration schemes allow to customize `PowerShell 7` in the most flexible way:
 
 - Enterprise system administrators can use GPO,
-    GPP and computer-wide settings files to apply approved configuration settings and mandatory security settings in a centralized manner.
+    Computer-wide settings files to apply approved configuration settings and mandatory security settings in a centralized manner.
     Most settings can be applied either to the user or computer-wide.
     We will cover the precedence of these in [Registry keys and settings](#registry-keys-and-settings).
 - Developers and consumers can use user, or computer-wide level setting files.

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -47,6 +47,7 @@ Configuration schemes allow to customize `PowerShell 7` in the most flexible way
 - Enterprise system administrators can use GPO,
     GPP and computer-wide settings files to apply approved configuration settings and mandatory security settings in a centralized manner.
     Most settings can be applied either to the user or computer-wide.
+    We will cover the precedence of these in [Registry keys and settings](#registry-keys-and-settings).
 - Developers and consumers can use user, or computer-wide level setting files.
 
 ### Configuration defaults

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -51,14 +51,14 @@ Configuration schemes allow to customize `PowerShell 7` in the most flexible way
 
 ### Configuration defaults
 
-PowerShell 7 has hard-coded defaults for all configuration options.
+PowerShell 7 has hard-coded defaults for all configuration policies and settings.
 
 The default values must be `secure-by-default`.
 
 For release versions hard-coded defaults must be the same as ones in pre-installed configuration files. For preview versions they may vary (ex., enable experimental features and so on).
 
 Computer-wide configuration includes security sensitive setting,
-and failing to read those setting could result in an insecure system.
+and failing to read those setting, for example if the file is locked or corrupted, could result in an insecure system.
 So, if during startup, PowerShell 7 cannot read files read from the Computer-Wide scope,
 it fails to startup.
 

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -28,14 +28,14 @@ I based this off of @iSazonov 's RFC, for just a slightly different purpose.
 
 ## Definitions
 
-- **Computer-Wide settings/policy**  - setting or policy applied to the entire operating system.
-- **User settings/policy** - setting or policy applied only to the user.
+- **Computer-Wide settings/policy**  - setting or policy applied to an operating system environment (OSE), affecting all users of the OSE.
+- **User settings/policy** - setting or policy applied to a specific user of an OSE, and not applied to the OSE as a whole.
 
 ## Specification
 
 `PowerShell 7` should be configured using the following schemes:
 
-- On Windows - Group Policy Objects (GPO), Group Policy Preferences (GPP) and settings files.
+- On Windows - Group Policy Objects (GPO), and settings files.
 - On Unix - settings files.
 
 The settings files have `JSON` format.

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -29,7 +29,7 @@ I based this off of @iSazonov 's RFC, for just a slightly different purpose.
 ## Definitions
 
 - **Computer-Wide settings/policy**  - setting or policy applied to an operating system environment (OSE), affecting all users of the OSE.
-- **User settings/policy** - setting or policy applied to a specific user of an OSE, and not applied to the OSE as a whole.
+- **Per-User settings/policy** - setting or policy applied to a specific user of an OSE, and not applied to the OSE as a whole.
 
 ## Specification
 
@@ -130,14 +130,14 @@ With `-settingsfile` parameter users can assign custom settings from the config 
   only trusted code runs in Full Language mode.
   See [PowerShell Constrained Language Mode](https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode/)
 
-##### Computer-wide and user policy settings
+##### Computer-wide and per-user policy settings
 
-Admin/root users can overwrite computer-wide and user policy settings using `-settingsfile`,
+Admin/root users can overwrite computer-wide and per-user policy settings using `-settingsfile`,
 only when not in System Lock-down mode.
 
 This will have performance impact on startup, but only when `-settingsfile` is specified.
 
-#### Precedence for User settings in descending order
+#### Precedence for Per-user settings in descending order
 
 Note, this is listed as `User, then Computer` in [Registry keys and settings](#registry-keys-and-settings).
 
@@ -187,7 +187,7 @@ Notes:
 | Transcription               | OutputDirectory                    | String | Computer, Then User |
 | UpdatableHelp               | DefaultSourcePath                  | String | Computer Wide       |
 
-I filed [#9632](https://github.com/PowerShell/PowerShell/issues/9632) on UpdatableHelp-DefaultSourcePath to make it allow User settings.
+I filed [#9632](https://github.com/PowerShell/PowerShell/issues/9632) on UpdatableHelp-DefaultSourcePath to make it allow Per-user settings.
 
 #### JSON file settings format
 

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -73,7 +73,7 @@ PowerShell 7 does not update configuration values from modified configuration fi
 
 ### Settings locations
 
-`PowerShell 7` settings are grouped into `Policy settings` and `Regular settings`.
+`PowerShell 7` settings are grouped into `Policy settings` and `Non-policy settings`.
 Regular settings are normal configuration settings.
 Regular settings can be treated as default and recommended values.
 Policy settings have a higher precedence than regular settings.

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -12,7 +12,7 @@ Comments Due: 6/30/2019
 
 ## Motivation
 
-Consumers, developers, and enterprise system administrators should be able to flexibly and reliable configure PowerShell 7.
+Consumers, developers, and enterprise system administrators should be able to flexibly and reliably configure PowerShell 7.
 
 ## Acknowledgement
 
@@ -71,7 +71,7 @@ If during operation PowerShell 7 cannot read configuration files it continue to 
 `PowerShell 7` settings are grouped into `Policy settings` and `Regular settings`.
 Regular settings are normal configuration settings.
 Regular settings can be treated as default and recommended values.
-Policy settings is higher precedence.
+Policy settings have a higher precedence than regular settings.
 See [Precedence for Policy settings in descending order](#precedence-for-policy-settings-in-descending-order).
 Policy settings are used by administrators to centrally manage PowerShell.
 

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -23,7 +23,7 @@ I based this off of @iSazonov 's RFC, for just a slightly different purpose.
 
 1. Specify how PowerShell 7 will deal with having both Windows PowerShell and PowerShell Core Group Policy.
     - This is covered in [Policy settings Setting Fall-Back](#policy-settings-setting-fall-back).
-1. Correct how the `pwsh -settingsfile` switch behaves.
+1. Define how the `pwsh -settingsfile` switch should behave.
     - This is covered in  [Parameter `-settingsfile`](#Parameter--settingsfile)
 
 ## Definitions
@@ -64,7 +64,7 @@ it fails to startup.
 
 If during startup PowerShell 7 cannot read user configuration files it uses _hardcoded_ defaults.
 
-If during operation PowerShell 7 cannot read configuration files it continue to use _current_ (runtime) configuration values.
+PowerShell 7 does not update configuration values from modified configuration files during a given session after the configuration has been loaded.
 
 ### Settings locations
 

--- a/1-Draft/RFCXXXX-Policy.md
+++ b/1-Draft/RFCXXXX-Policy.md
@@ -25,6 +25,7 @@ I based this off of @iSazonov 's RFC, for just a slightly different purpose.
     - This is covered in [Policy settings Setting Fall-Back](#policy-settings-setting-fall-back).
 1. Define how the `pwsh -settingsfile` switch should behave.
     - This is covered in  [Parameter `-settingsfile`](#Parameter--settingsfile)
+1. Specify where setting will be read from on various supported platforms.
 
 ## Definitions
 

--- a/2-Draft-Accepted/RFC0041-Policy.md
+++ b/2-Draft-Accepted/RFC0041-Policy.md
@@ -1,7 +1,7 @@
 ---
-RFC:  RFCnnnn
-Author:  travisez13
-Status:  Draft
+RFC: RFC0041
+Author: travisez13
+Status: Draft-Accepted
 SupercededBy:  N/A
 Version: 0.1
 Area: Engine


### PR DESCRIPTION
<!--

All new RFCs must:

* have examples of the proposed behavior, preferably in the form of a script (or scripts) which shows the proposed behavior with comments and annotations

All new RFCs should:

* Not have a number - maintainers will assign the number
* Be placed in the Draft folder

Maintainers will sometimes need to make small edits (for example, set the RFC number).
To make this easier, we suggest giving maintainers permission to push to your fork,
see https://github.com/blog/2247-improving-collaboration-with-forks.

Also be sure to read https://github.com/PowerShell/PowerShell-RFC/blob/master/RFC0000-RFC-Process.md

-->

The main goal here is to describe various policy and setting fall-back behavior:  

1. When things like `-settingsfile` will be allowed to overwrite, what type of settings.
2. When PowerShell Core will use Windows PowerShell Policy, and how.
3. Where various policies/settings are read from.