### PR TITLE
PowerShellGet 3.0

### DIFF
--- a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
+++ b/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
@@ -132,7 +132,7 @@ always connect to that repository.
 ### Repository management
 
 `Register-PSResourceRepository` will allow for registering additional repositories.
-A `-Default` switch enables registering PSGallery should it be accidentally removed.
+A `-PSGallery` switch enables registering PSGallery should it be accidentally removed.
 The `-URL` will accept the HTTP address without the need to specify `/api/v3` as
 that will be assumed and discovered at runtime (trying v3 first, then falling
 back to v2, then the literal URL).
@@ -145,22 +145,22 @@ the parameter names (like splatting).
 
 ```powershell
 Register-PSResourceRepository -Repositories @(
-  @{ URL = "https://one.com"; Trusted = $true }
-  @{ URL = "https://powershellgallery.com"; Trusted = $true; Default = $true }
+  @{ URL = "https://one.com"; Name = "One"; Trusted = $true; Credential }
+  @{ URL = "https://powershellgallery.com"; Name = "PSGallery"; Trusted = $true; Default = $true }
 )
 ```
 
 A `-Name` parameter allows for setting a friendly name.
 
-A `-Default` switch will set one repository as the default (when not specified
-with other cmdlets).
-Each time it is specified, it sets the new one as default and the previous default
-is no longer default.
+A `-Priority` parameter allows setting the search order of repositories.
+A lower value has higher priority.
+If not specified, the default value is 50.
+PSGallery will have a default value of 25.
 
 `Get-PSResourceRepository` will list out the registered repositories.
 
 `Set-PSResourceRepository` can be used to update a repository URL, trust level,
-or if that repository is the default.
+or priority.
 
 `Unregister-PSResourceRepository` can be used to un-register a repository.
 
@@ -318,8 +318,10 @@ nupkg) instead of expanding it into a folder.
 ### Updating resources
 
 `Update-PSResource` will update all resources to most recent minor version by default.
-A `-AllowMajorVersionUpdate` switch will allow updating to newer major version.
-A `-PatchUpdateOnly` switch will allow updating only to patched versions.
+
+A `-UpdateTo` parameter has values `MinorVersion` (as default), `MajorVersion`, `PatchVersion`.
+`MajorVersion` allows updating to latest major version.
+`PatchVersion` allows updating to latest patch version (e.g. 6.2.1 to 6.2.4).
 
 If the installed resource is a pre-release, it will automatically update to
 latest prerelease or stable version (if available).
@@ -369,15 +371,22 @@ a well known REST API and return a more descriptive error message to the user.
 
 ## Alternate Proposals and Considerations
 
-This RFC does not cover the module authoring experience on publishing a cross-platform
-module with multiple dependencies and supporting multiple runtimes.
+These are items are outside the scope of this RFC and version 3.0.
+Many of these items can be addressed in a future version of PowerShellGet without
+introducing a breaking change:
 
-If there is a desire to explicitly update the local cache (like `apt`), we can introduce a
-`Update-PSResourceCache` cmdlet in the future and a property on PSRepository registrations
-indicating whether it auto-updates or not.
-This would not be a breaking change, but not part of this initial release.
+- This RFC does not cover the module authoring experience on publishing a cross-platform
+  module with multiple dependencies and supporting multiple runtimes.
 
-The ability to set policy for PSGet is outside the scope of this RFC.
+- If there is a desire to explicitly update the local cache (like `apt`), we can introduce a
+  `Update-PSResourceCache` cmdlet in the future and a property on PSRepository registrations
+  indicating whether it auto-updates or not.
 
-Automatic cleanup of old resources is out of scope of this RFC.
-Keeping with current behavior, installs are always side-by-side.
+- The ability to set policy for PSGet
+
+- Automatic cleanup of old resources when upgrading or removing resources
+
+- Signing incorporated into `Publish-PSResource`
+
+- `-Trusted` switch to `Install-PSResource` and `Find-PSResource` that pre-validates
+  the signing cert is trusted on the system

--- a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
+++ b/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
@@ -372,7 +372,7 @@ a well known REST API and return a more descriptive error message to the user.
 ## Alternate Proposals and Considerations
 
 These are items are outside the scope of this RFC and version 3.0.
-Many of these items can be addressed in a future version of PowerShellGet without
+Many of these items can be addressed in a future version of PowerShellGet 3.x without
 introducing a breaking change:
 
 - This RFC does not cover the module authoring experience on publishing a cross-platform
@@ -390,3 +390,5 @@ introducing a breaking change:
 
 - `-Trusted` switch to `Install-PSResource` and `Find-PSResource` that pre-validates
   the signing cert is trusted on the system
+
+- Notify users that they have outdated versions of a module (just patch versions?)

--- a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
+++ b/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
@@ -106,7 +106,7 @@ currently published to PowerShellGallery.com) is ~700KB in compressed json form.
 The cache would have both latest stable and latest prerelease versions of resources.
 
 >[!NOTE]
->Need to experiment if it makes sense to have a single cache file for a repositories
+>Need to experiment if it makes sense to have a single cache file for all repositories
 >or a different cache per repository for size and perf reasons.
 >Perf tests will determine if the cache needs to be in binary form.
 

--- a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
+++ b/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
@@ -332,6 +332,11 @@ Version  Name       Type    Repository  Description
 >[!NOTE]
 >Uninstalling dependencies automatically will be something to consider in the future.
 
+### PowerShellGallery status
+
+Upon failure to connect to PSGallery, the cmdlets should retrieve status from
+a well known REST API and return a more descriptive error message to the user.
+
 ## Alternate Proposals and Considerations
 
 This RFC does not cover the module authoring experience on publishing a cross-platform

--- a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
+++ b/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
@@ -108,8 +108,7 @@ The cache would have both latest stable and latest prerelease versions of resour
 >[!NOTE]
 >Need to experiment if it makes sense to have a single cache file for a repositories
 >or a different cache per repository for size and perf reasons.
-
-Perf tests will determine if the cache needs to be in binary form.
+>Perf tests will determine if the cache needs to be in binary form.
 
 ### Automatic updating of the cache
 
@@ -176,7 +175,8 @@ However, this cmdlet does not update the cache if one exists.
 
 ### Installing resources
 
-`Install-PSResource` will only work for modules.
+`Install-PSResource` will only work for modules unless `-DestinationPath` is
+specified which works for all resource types.
 A `-Prerelease` switch allows installing prerelease versions.
 Other types will use `Save-PSResource` (see below).
 A `-Repository` parameter accepts a specific repository name or URL to the repository:
@@ -220,7 +220,7 @@ loaded on Windows.
 
 ### Dependencies and version management
 
-`Install-PSResource` can accept a path to a psd1 file (using `-RequiredResourcesFile`),
+`Install-PSResource` can accept a path to a psd1 or json file (using `-RequiredResourcesFile`),
 or a hashtable or json (using `-RequiredResources`) where the key is the module name and the
 value is either the required version specified using Nuget version range syntax or
 a hash table where `repository` is set to the URL of the repository and
@@ -236,6 +236,25 @@ Install-PSResource -RequiredResources @{
   }
 }
 ```
+
+The json format will be the same as if this hashtable is passed to `ConvertTo-Json`:
+
+```json
+{
+  "Pester": {
+    "version": "[4.4.2,4.7.0]",
+    "credential": null,
+    "repository": "https://www.powershellgallery.com"
+  },
+  "Configuration": "[1.3.1,2.0)"
+}
+```
+
+>[!NOTE]
+>Credentials management will be using an upcoming RFC for generalized
+>credential management.  Not sure how to make that work in json other
+>than requiring json to have credential as a json object but that means
+>password/secret is in clear text.
 
 The `repository` property can be the name of the registered repository or the URL
 to a repository.
@@ -255,6 +274,8 @@ module to be installed.
 
 ### Saving resources
 
+This cmdlet uses `Install-PSResource -DestinationPath`.
+
 With the removal of PackageManagement, there is still a need to support saving
 arbitrary nupkgs (assemblies) used for scripts.
 
@@ -264,11 +285,12 @@ will be copied to the root of the destination specified.
 A `-IncludeAllRuntimes` can be used to explicitly retain the `runtimes` directory
 hierarchy within the nupkg to the root of the destination.
 
+>[!NOTE]
+>Library support may not be available in 3.0.
+
 A `-Prerelease` switch allows saving prerelease versions.
 If the `-Version` includes a prerelease label like `2.0.0-beta4`, then this
 switch is not necessary and the prerelease version will be installed.
-
-This cmdlet uses `Install-PSResource -DestinationPath`.
 
 ### Updating resources
 
@@ -306,7 +328,9 @@ Version  Name       Type    Repository  Description
 ### Uninstalling resources
 
 `Uninstall-PSResource` will be available to remove installed resources.
-Uninstalling dependencies will be something to consider in the future.
+
+>[!NOTE]
+>Uninstalling dependencies automatically will be something to consider in the future.
 
 ## Alternate Proposals and Considerations
 

--- a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
+++ b/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
@@ -1,0 +1,242 @@
+---
+RFC: RFCxxxx
+Author: Steve Lee
+Status: Draft
+SupercededBy: N/A
+Version: 0.1
+Area: PowerShellGet
+Comments Due: 7/30
+Plan to implement: Yes
+---
+
+# PowerShellGet 3.0 Module
+
+PowerShellGet has enabled an active community to publish and install PowerShell
+Modules.
+However, it has some architectural and design limitations that prevent it from
+moving forward more quickly.
+This RFC proposes some significant changes to address this.
+
+> [!NOTE]
+> There are no intentions to break existing PSGet v2 users so existing
+> users can stay on PSGet v2 and that will continue to work.
+
+## Motivation
+
+    As a PowerShell user,
+    I can discover how to install missing cmdlets,
+    so that I can be more productive.
+
+    As a PowerShellGet contributor,
+    I can more easily contribute code,
+    so that PowerShellGet evolves more quickly.
+
+## User Experience
+
+```powershell
+PS> Get-Satisfaction
+Get-Satisfaction : The term 'Get-Satisfaction' is not recognized as the name of a cmdlet, function, script file, or operable program.
+Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
+At line:1 char:1
++ Get-Satisfaction
++ ~~~
++ CategoryInfo          : ObjectNotFound: (Get-Satisfaction:String) [], CommandNotFoundException
++ FullyQualifiedErrorId : CommandNotFoundException
+
+Suggestion: You can obtain `Get-Satisfaction` by running `Install-PSResource HappyDays`.
+
+PS> Install-PSResource HappyDays
+```
+
+## Specification
+
+### Rewrite of PowerShellGet
+
+PowerShellGet is currently written as PowerShell script with a dependency on PackageManagement.
+Proposal is to write PSResource in C# to reduce complexity and make easier to maintain.
+In addition, remove dependency on PackageManagement completely as well as dependency on
+nuget.exe.
+This module will only use REST APIs to get and publish nupkgs.
+This module would be shipped in PowerShell 7.
+
+### Side-by-side with PowerShellGet
+
+To ease transition due to the enormity of the breaking change, this module will
+have a different names for the cmdlets to allow for side by side use
+with the existing PowerShellGet module.
+Since the current PowerShellGet 2.x version is a script module and this new one
+is a C# based module, they can coexist side-by-side.
+
+### Cmdlet compatibility
+
+Function wrappers will be provided to provide compatibility with the two most often
+used cmdlets: `Install-Module` and `Find-Module`.
+These cmdlets will output a warning to use the new cmdlets.
+
+### Local cache
+
+Rather than connecting to PSGallery and other repositories for finding modules,
+the user must explicitly request the current metadata of
+modules from the repositories and that is cached locally.
+`Find-PSResource` (see below) works against this local cache.
+This will also enable changes in PowerShell to use `Find-PSResource -Type Command` to look
+in this cache when it can't find a command and suggest to the user the module to install to
+get that command.
+This will be a local json file containing only the latest version of each module.
+The cache will be stored in the user path.
+There is no system cache that is shared.
+
+Example cache entry:
+
+```json
+{
+  "name": "This is my module",
+  "version": "1.0.0.0",
+  "type": "module",
+  "tags": [
+    "Linux",
+    "PSEdition_Core",
+    "PSEdition_Desktop",
+    "AzureAutomation"
+  ]
+}
+```
+
+An example cache with 5000 resources is ~700KB in compressed json form.
+
+### Automatic updating of the cache
+
+On any operation that reaches out to a repository, a REST API will be called to
+see if the hash of the cache matches the current cache and if not, a new one
+is downloaded.
+If the repository doesn't support this new API, it falls back to current behavior
+in PSGet v2.
+
+### Repository management
+
+`Register-PSResourceRepository` will allow for registering additional repositories.
+A `-Default` switch enables registering PSGallery should it be accidentally removed.
+The `-URL` will accept the HTTP address without the need to specify `/api/v2` as
+that will be assumed and discovered at runtime.
+Support for local filesystem repositories must be maintained.
+A `-InstallationPolicy` switch accepts `Trusted` or `Untrusted` (default) indicating
+whether to prompt the user when installing resources from that repository.
+
+`Get-PSResourceRepository` will list out the registered repositories.
+
+`Set-PSResourceRepository` can be used to update a repository URL or installation policy.
+
+`Unregister-PSResourceRepository` can be used to un-register a repository.
+
+### Finding resources
+
+Current design of PowerShellGet is to have different cmdlets for each of the
+different resources types that it supports:
+
+`Find-Command`
+`Find-DscResource`
+`Find-Module`
+`Find-RoleCapability`
+`Find-Script`
+
+Instead, these will be abstracted by a `Find-PSResource` cmdlet.
+A `-Type` parameter will accept an array of types to allow filtering.
+
+With support of the generic `PSResource`, this means we can also find and
+install arbitrary nupkgs that may only contain an assembly the user wants to
+use in their script.
+
+If the local cache does not exist, the cmdlet will call `Update-PSResourceCache`
+first and then attempt a search.
+However, this cmdlet does not update the cache if one exists.
+
+### Installing resources
+
+`Install-PSResource` will only work for modules.
+A `-AllowPrerelease` switch allows installing prerelease versions.
+Other types will use `Save-PSResource` (see below).
+A `-Repository` parameter accepts a specific repository name.
+If `-Repository` is not specified and the same resource is found in multiple
+repositories, then the resource is automatically installed quietly from the
+trusted repository with the highest version matching the `-Version` parameter
+(if specified, otherwise newest non-prerelease version unless `-AllowPrerelease`
+is used).
+If there are no trusted repositories matching the query, then the newest version
+fulfilling the query will be prompted to be installed.
+If there are multiple repositories with the same trust level containing the same
+version, the first one is used.
+
+`-AllowUntrusted` can be used to suppress being prompted for untrusted sources.
+`-AllowDifferentPublisher` can be used to suppress being prompted if the publisher
+of the module is different from the currently installed version.
+`-AllowReinstall` can be used to re-install a module.
+
+A `-Quiet` switch will suppress progress information.
+
+### Dependencies and version management
+
+`Install-PSResource` can accept a path to a psd1 file (using `-RequiredModulesFile`)
+or a hashtable (using `-RequiredModules`) where the key is the module name and the
+value is either the required version specified using Nuget version range syntax or
+a hash table where `repository` is set to the URL of the repository and
+`version` contains the [Nuget version range syntax](https://docs.microsoft.com/en-us/nuget/reference/package-versioning#version-ranges-and-wildcards).
+
+```powershell
+Install-PSResource -RequiredModules @{
+  "Configuration" = "[1.3.1,2.0)"
+  "Pester"        = @{
+    version = "[4.4.2,4.7.0]"
+    repository = "https://www.powershellgallery.com"
+  }
+}
+```
+
+### Saving resources
+
+With the removal of PackageManagement, there is still a need to support saving
+arbitrary nupkgs (assemblies) used for scripts.
+
+`Save-PSResource -Type Library` will download nupkgs that have a `lib` folder.
+A `-AllowPrerelease` switch allows saving prerelease versions.
+The dependent native library in `runtimes` matching the current system runtime
+will be copied to the same destination.
+
+This cmdlet has the same parameters as `Install-PSResource` with the addition
+of mandatory `-Path` or `-LiteralPath` parameters.
+
+### Updating resources
+
+`Update-PSResource` will update all resources to most recent minor version by
+default.
+A `-OnlyMinorUpdates` switch will allow only updating to newer minor version.
+If the installed resource is a pre-release, it will automatically update to
+latest prerelease or stable version (if available).
+
+### Publishing resources
+
+`Publish-PSResource` will supporting publishing modules and scripts.
+Modules will be given as a path to the module folder.
+Publishing by name and version is no longer supported.
+
+### Listing installed resources
+
+`Get-PSResource` will list all installed resources with new `Type` column.
+
+```output
+Version  Name       Type    Repository  Description
+-------  ----       ----    ----------  -----------
+5.0.0    VSTeam     Module  PSGallery   Adds functionality for working with Visual …
+0.14.94  PSGitHub   Module  PSGallery   This PowerShell module enables integration …
+0.7.3    posh-git   Module  PSGallery   Provides prompt with Git status summary …
+1.0.1    PSAutoMute Script  PSGallery   Powershell script to Auto Mute you sound devices …
+```
+
+## Alternate Proposals and Considerations
+
+This RFC does not cover the module authoring experience on publishing a cross-platform
+module with multiple dependencies and supporting multiple runtimes.
+
+If there is a desire to explicitly update the local cache (like `apt`), we can introduce a
+`Update-PSResourceCache` cmdlet with property on a PSRepository indicating whether
+it auto-updates or not.
+This would not be a breaking change.

--- a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
+++ b/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
@@ -5,7 +5,7 @@ Status: Draft
 SupercededBy: N/A
 Version: 0.2
 Area: PowerShellGet
-Comments Due: 7/30
+Comments Due: 6/30
 Plan to implement: Yes, PS7
 ---
 

--- a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
+++ b/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md
@@ -161,7 +161,7 @@ A `-Name` parameter allows for setting a friendly name.
 
 A `-Priority` parameter allows setting the search order of repositories.
 A lower value has higher priority.
-If not specified, the default value is 25.
+If not specified, the default value is 50.
 PSGallery will have a default value of 50.
 
 `Get-PSResourceRepository` will list out the registered repositories.
@@ -241,10 +241,8 @@ Default is `CurrentUser`.
 
 `Install-Module` cmdlet will be retained for compatibility with v2.
 
-A change from v2 is that installed modules use the full semver (if used) of
-the module, so PSReadLine would be in a folder called `2.0.0-beta4` instead of
-just `2.0.0` which resolves issues of attempting to overwrite assemblies currently
-loaded on Windows.
+v3 will continue to use the versioning folder format as v2 in that it will be
+Major.Minor.Patch and not contain the semver prerelease label.
 
 ### Dependencies and version management
 
@@ -261,6 +259,7 @@ Install-PSResource -RequiredResources @{
     version = "[4.4.2,4.7.0]"
     repository = "https://www.powershellgallery.com"
     credential = $cred
+    allowPrerelease = $true
   }
 }
 ```
@@ -269,20 +268,19 @@ The json format will be the same as if this hashtable is passed to `ConvertTo-Js
 
 ```json
 {
+  "Configuration": "[1.3.1,2.0)",
   "Pester": {
     "version": "[4.4.2,4.7.0]",
     "credential": null,
-    "repository": "https://www.powershellgallery.com"
-  },
-  "Configuration": "[1.3.1,2.0)"
+    "repository": "https://www.powershellgallery.com",
+    "allowPrerelease": true
+  }
 }
 ```
 
 >[!NOTE]
->Credentials management will be using an upcoming RFC for generalized
->credential management.  Not sure how to make that work in json other
->than requiring json to have credential as a json object but that means
->password/secret is in clear text.
+>Credentials management will be using [Secrets Management RFC](https://github.com/PowerShell/PowerShell-RFC/pull/208)
+> for generalized credential management.
 
 The `repository` property can be the name of the registered repository or the URL
 to a repository.
@@ -290,9 +288,6 @@ If no `repository` is specified, it will use the `default` repository.
 
 The older `System.Version` four part version type will be supported to retain
 compatibility with existing published modules using that format.
-
-Due to the differences between semver and `System.Version`, we may have to keep
-the two distinct.
 
 If the resource requires dependencies that are not already installed, then
 a prompt will appear _before anything is installed_, listing all the resources
@@ -415,4 +410,12 @@ introducing a breaking change:
 
 - Enterprise management of local cache
 
+- Full semver support won't happen until there is a semver type in .NET
+
+- Consider using a merkle tree to validate modules
+
 PowerShell module loading needs to be updated to [understand semver](https://github.com/PowerShell/PowerShell/issues/2983).
+
+Instead of `Find-PSResource`, call it `Find-Resource`.
+Context may be understandable since the cmdlet comes from PowerShellGet, but
+`Resource` as a noun is pretty general.


### PR DESCRIPTION
Note, this includes breaking changes from PSGet v2.  However, PSGet v2 users can continue to stay on v2.