### PR TITLE
Add the time of the Community Call

### DIFF
--- a/CommunityCall/README.md
+++ b/CommunityCall/README.md
@@ -1,6 +1,6 @@
 # PowerShell Core Community Call
 
-The PowerShell Community Call is held on the 3rd Thursday of every month.
+The PowerShell Community Call is held on the 3rd Thursday of every month at [9:30 AM US Pacific Time](http://www.timebie.com/std/pdt.php?q=9.5).
 Topics include PowerShell Core, PSEditorServices/VSCode-PowerShell, PSScriptAnalyzer,
 PowerShell Gallery, and any other projects owned by the PowerShell Team.
 


### PR DESCRIPTION
Adds the time of the community call to the ReadMe for the community call so that it can be more easily determined.

Includes a link to http://www.timebie.com/std/pdt.php?q=9.5 which appears to convert into the users local time and lists common worldwide times near the bottom of the page.

<!--

All new RFCs must:

* have examples of the proposed behavior, preferably in the form of a script (or scripts) which shows the proposed behavior with comments and annotations

All new RFCs should:

* Not have a number - maintainers will assign the number
* Be placed in the Draft folder

Maintainers will sometimes need to make small edits (for example, set the RFC number).
To make this easier, we suggest giving maintainers permission to push to your fork,
see https://github.com/blog/2247-improving-collaboration-with-forks.

Also be sure to read https://github.com/PowerShell/PowerShell-RFC/blob/master/RFC0000-RFC-Process.md

-->

